### PR TITLE
Supporting parameters in views

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIViewProvider.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIViewProvider.java
@@ -222,11 +222,17 @@ public class CDIViewProvider implements ViewProvider {
     }
 
     private String parseViewName(String viewAndParameters) {
-        if (viewAndParameters.startsWith("!")) {
-            return viewAndParameters.substring(1);
+
+        String viewName = viewAndParameters;
+        if (viewName.startsWith("!")) {
+            viewName = viewName.substring(1);
+        }
+        
+        if (viewName.contains("/")) {
+            viewName = viewName.split("/")[0];
         }
 
-        return viewAndParameters;
+        return viewName;
     }
 
     private static Logger LOG() {


### PR DESCRIPTION
When I tried to load a view with paramegers (e.g. myview/123), the addon tried to find a view 'myview/123', but there is only a view 'myview'. I changed method parseViewName. Now it splits the parameter from the viewname  to find the correct view.
