### PR TITLE
Update pom to Vaadin 7.0.0

### DIFF
--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.0-SNAPSHOT</vaadin.version>
+		<vaadin.version>7.0.0</vaadin.version>
 	</properties>
 	
     <name>vaadin-cdi</name>
@@ -30,12 +30,12 @@
     <repositories>
         <repository>
             <id>vaadin-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>http://oss.sonatype.org/content/repositories/vaadin-release/</url>
             <releases>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </releases>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
Vaadin 7 final is out so please import vaadin-cdi-integraion to vaadin maven repository.
