### PR TITLE
Support for CDI environments that do not support injection into servlet context listeners

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
@@ -196,12 +196,23 @@ public class CDIUIProvider extends DefaultUIProvider implements Serializable {
         if (beanManager == null) {
             // as the CDIUIProvider is not injected, need to use JNDI lookup
             try {
-                InitialContext initialContext = new InitialContext();
+            	InitialContext initialContext = new InitialContext();
                 beanManager = (BeanManager) initialContext
                         .lookup("java:comp/BeanManager");
             } catch (NamingException e) {
-                getLogger().severe("Could not get BeanManager through JNDI");
-                beanManager = null;
+                getLogger().info("Could not get BeanManager through JNDI by name 'java:comp/BeanManager'. Try with name 'java:comp/env/BeanManager'");
+
+                try
+                {
+	            	InitialContext initialContext = new InitialContext();
+	                beanManager = (BeanManager) initialContext
+	                        .lookup("java:comp/env/BeanManager");
+                }
+                catch(NamingException e2)
+                {
+                    getLogger().info("Could not get BeanManager through JNDI");
+                    beanManager = null;
+                }
             }
         }
         return beanManager;

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/ContextDeployer.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/ContextDeployer.java
@@ -47,6 +47,13 @@ public class ContextDeployer implements ServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
+    	
+    	if(beanManager == null)
+    	{
+    		getLogger().info("The container does not support injection into a servlet listener!");
+    		return;
+    	}
+    	
         configuredUIs = new HashSet<String>();
 
         ServletContext context = sce.getServletContext();


### PR DESCRIPTION
I want to use Vaadin with CDI in a servlet container like Tomcat 7.

To make CDI available in Tomcat, I use the weld-servlet, which not supports injection into listeners. Unfortunately, the vaadin-cdi-integration is using a context listener to deploy the vaadin servlet.

In my commit, the ContextDeployer is only executed if the injection of the BeanManager was successful. In the case you have to specify the Vaadin servlet on the CDIUIProvider in the web.xml.

In the CDIUIProvider, if the BeanManager is not found by the name "java:comp/BeanManager" then it also tries to lookup with the name "java:comp/env/BeanManager" (Tomcat provides resource under "java:comp/env/". You must also specify the BeanManager as a resource in the context.xml and in the web.xml as described at http://docs.jboss.org/weld/reference/1.0.0/en-US/html/environments.html#d0e4998.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/20)
<!-- Reviewable:end -->
