### PR TITLE
some test related fixes, and managed arquillian test profiles for glassfish, and wildfly

### DIFF
--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -16,10 +16,9 @@
         <deltaspike.version>1.7.2</deltaspike.version>
 
         <!-- Testing dependencies -->
-        <selenium.version>2.47.1</selenium.version>
-        <!-- This needs to be in sync with the class ShiroTest -->
+        <selenium.version>2.53.0</selenium.version>
         <shiro.version>1.3.2</shiro.version>
-        <arquillian.version>1.1.10.Final</arquillian.version>
+        <arquillian.version>1.1.11.Final</arquillian.version>
 
         <!-- ZIP Manifest fields -->
         <Implementation-Version>${project.version}</Implementation-Version>
@@ -201,6 +200,65 @@
                 </dependency>
             </dependencies>
         </profile>
+
+        <profile>
+            <id>wildfly</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>2.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax</groupId>
+                    <artifactId>javaee-api</artifactId>
+                    <version>7.0</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>10.1.0.Final</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>target</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <jboss.home>${project.build.directory}/wildfly-10.1.0.Final</jboss.home>
+                            </systemPropertyVariables>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -248,7 +306,7 @@
             <version>${deltaspike.version}</version>
             <scope>runtime</scope>
         </dependency>
-        
+
         <dependency>
            <groupId>javax.enterprise</groupId>
            <artifactId>cdi-api</artifactId>
@@ -271,9 +329,9 @@
         <!-- Graphene -->
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>
-            <artifactId>arquillian-graphene</artifactId>
+            <artifactId>graphene-webdriver</artifactId>
             <type>pom</type>
-            <version>2.1.0.Alpha3</version>
+            <version>2.1.0.Final</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -259,6 +259,63 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>glassfish</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-managed-3.1</artifactId>
+                    <version>1.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax</groupId>
+                    <artifactId>javaee-api</artifactId>
+                    <version>7.0</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish.main.distributions</groupId>
+                                            <artifactId>glassfish</artifactId>
+                                            <version>4.1.1</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>target</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/glassfish4</GLASSFISH_HOME>
+                            </environmentVariables>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import javax.enterprise.inject.New;
 
 import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -20,6 +21,7 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.cdi.uis.RootUI;
 
 @RunWith(Arquillian.class)
+@RunAsClient
 abstract public class AbstractCDIIntegrationTest {
 
     @Drone

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
@@ -64,10 +64,4 @@ abstract public class AbstractCDIIntegrationTest {
         return findElement(By.id(id));
     }
 
-    public void sleep(int millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-        }
-    }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractCDIIntegrationTest.java
@@ -1,13 +1,5 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import javax.enterprise.inject.New;
-
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -18,7 +10,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.cdi.uis.RootUI;
+import javax.enterprise.inject.New;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -46,10 +40,6 @@ abstract public class AbstractCDIIntegrationTest {
             throws MalformedURLException {
         URL url = new URL(contextPath.toString() + uri);
         window.navigate().to(url);
-    }
-    
-    public void assertDefaultRootNotInstantiated() {
-        assertThat(RootUI.getNumberOfInstances(), is(0));
     }
 
     public int number(String txt) {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -61,6 +62,23 @@ public abstract class AbstractManagedCDIIntegrationTest extends
                         return value.equals(driver.findElement(by).getText());
                     }
                 });
+    }
+
+    public void clickAndWait(String id) {
+        findElement(id).click();
+        waitForClient();
+    }
+
+    public void waitForClient() {
+        new WebDriverWait(firstWindow, 10).until(new ClientIsReadyPredicate());
+    }
+
+    private class ClientIsReadyPredicate implements Predicate<WebDriver> {
+        @Override
+        public boolean apply(WebDriver input) {
+            return (Boolean) ((JavascriptExecutor) firstWindow)
+                    .executeScript("return !vaadin.clients[Object.keys(vaadin.clients)[0]].isActive()");
+        }
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -44,6 +44,16 @@ public abstract class AbstractManagedCDIIntegrationTest extends
         openWindowNoWait(firstWindow, uri, contextPath);
     }
 
+    public void refreshWindow() {
+        refreshWindow(firstWindow);
+    }
+
+    public void refreshWindow(WebDriver window) {
+        window.navigate().refresh();
+        (new WebDriverWait(window, 15)).until(ExpectedConditions
+                .presenceOfElementLocated(LABEL));
+    }
+
     public void waitForValue(final By by, final int value) {
         Graphene.waitModel(firstWindow).withTimeout(10, TimeUnit.SECONDS)
                 .until(new Predicate<WebDriver>() {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -1,13 +1,8 @@
 package com.vaadin.cdi;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.base.Predicate;
+import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.uis.RootUI;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.openqa.selenium.By;
@@ -16,8 +11,16 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.google.common.base.Predicate;
-import com.vaadin.cdi.internal.Conventions;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public abstract class AbstractManagedCDIIntegrationTest extends
         AbstractCDIIntegrationTest {
@@ -103,6 +106,10 @@ public abstract class AbstractManagedCDIIntegrationTest extends
 
     public void waitForClient() {
         new WebDriverWait(firstWindow, 10).until(new ClientIsReadyPredicate());
+    }
+
+    public void assertDefaultRootNotInstantiated() throws IOException {
+        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(0));
     }
 
     private class ClientIsReadyPredicate implements Predicate<WebDriver> {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -8,6 +8,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -101,6 +102,11 @@ public abstract class AbstractManagedCDIIntegrationTest extends
 
     public void clickAndWait(String id) {
         findElement(id).click();
+        waitForClient();
+    }
+
+    public void clickAndWait(By by) {
+        findElement(by).click();
         waitForClient();
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -1,5 +1,9 @@
 package com.vaadin.cdi;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +76,24 @@ public abstract class AbstractManagedCDIIntegrationTest extends
                         return value.equals(driver.findElement(by).getText());
                     }
                 });
+    }
+
+    public void resetCounts() throws IOException {
+        slurp("?resetCounts");
+    }
+
+    public int getCount(String id) throws IOException {
+        String line = slurp("?getCount=" + id);
+        return Integer.parseInt(line);
+    }
+
+    private String slurp(String uri) throws IOException {
+        URL url = new URL(contextPath.toString()+uri);
+        InputStream is = url.openConnection().getInputStream();
+        BufferedReader reader = new BufferedReader( new InputStreamReader( is )  );
+        String line = reader.readLine();
+        reader.close();
+        return line;
     }
 
     public void clickAndWait(String id) {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/AbstractManagedCDIIntegrationTest.java
@@ -8,7 +8,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -115,7 +114,7 @@ public abstract class AbstractManagedCDIIntegrationTest extends
     }
 
     public void assertDefaultRootNotInstantiated() throws IOException {
-        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(0));
+        assertThat(getCount(RootUI.CONSTRUCT_COUNT), is(0));
     }
 
     private class ClientIsReadyPredicate implements Predicate<WebDriver> {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ArchiveProvider.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ArchiveProvider.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi;
 
 import javax.enterprise.inject.spi.Extension;
 
+import com.vaadin.cdi.internal.*;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -27,23 +28,6 @@ import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
 
 import com.vaadin.cdi.access.AccessControl;
 import com.vaadin.cdi.access.JaasAccessControl;
-import com.vaadin.cdi.internal.AbstractVaadinContext;
-import com.vaadin.cdi.internal.AnnotationUtil;
-import com.vaadin.cdi.internal.ContextDeployer;
-import com.vaadin.cdi.internal.Conventions;
-import com.vaadin.cdi.internal.InconsistentDeploymentException;
-import com.vaadin.cdi.internal.UIBean;
-import com.vaadin.cdi.internal.UIContextual;
-import com.vaadin.cdi.internal.UIScopedContext;
-import com.vaadin.cdi.internal.VaadinExtension;
-import com.vaadin.cdi.internal.VaadinSessionDestroyEvent;
-import com.vaadin.cdi.internal.VaadinUICloseEvent;
-import com.vaadin.cdi.internal.VaadinViewChangeCleanupEvent;
-import com.vaadin.cdi.internal.VaadinViewChangeEvent;
-import com.vaadin.cdi.internal.VaadinViewCreationEvent;
-import com.vaadin.cdi.internal.ViewBean;
-import com.vaadin.cdi.internal.ViewContextual;
-import com.vaadin.cdi.internal.ViewScopedContext;
 import com.vaadin.cdi.server.VaadinCDIServlet;
 import com.vaadin.cdi.server.VaadinCDIServletService;
 
@@ -64,8 +48,9 @@ public class ArchiveProvider {
             CDIUIProvider.DetachListenerImpl.class,
             CDIViewProvider.ViewChangeListenerImpl.class, Conventions.class,
             InconsistentDeploymentException.class, AnnotationUtil.class,
-            URLMapping.class };
-
+            VaadinExtension.class, VaadinContextualStorage.class, ContextWrapper.class,
+            CDIUtil.class,
+            UIScoped.class, ViewScoped.class, NormalUIScoped.class, NormalViewScoped.class};
     public static WebArchive createWebArchive(String warName, Class... classes) {
         return createWebArchive(warName, true, classes);
     }
@@ -87,6 +72,9 @@ public class ArchiveProvider {
                 .addClasses(FRAMEWORK_CLASSES)
                 .addAsLibraries(
                         pom.resolve("com.vaadin:vaadin-server")
+                                .withTransitivity().asFile())
+                .addAsLibraries(
+                        pom.resolve("com.vaadin:vaadin-client-compiled")
                                 .withTransitivity().asFile())
                 .addAsLibraries(
                         pom.resolve("com.vaadin:vaadin-themes")

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ArchiveProvider.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ArchiveProvider.java
@@ -49,8 +49,9 @@ public class ArchiveProvider {
             CDIViewProvider.ViewChangeListenerImpl.class, Conventions.class,
             InconsistentDeploymentException.class, AnnotationUtil.class,
             VaadinExtension.class, VaadinContextualStorage.class, ContextWrapper.class,
-            CDIUtil.class,
-            UIScoped.class, ViewScoped.class, NormalUIScoped.class, NormalViewScoped.class};
+            CDIUtil.class, URLMapping.class,
+            UIScoped.class, ViewScoped.class, NormalUIScoped.class, NormalViewScoped.class,
+            CounterFilter.class, Counter.class};
     public static WebArchive createWebArchive(String warName, Class... classes) {
         return createWebArchive(warName, true, classes);
     }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingDeploymentTest.java
@@ -38,7 +38,7 @@ public class CDIIntegrationWithConflictingDeploymentTest extends
         resetCounts();
     }
 
-    @Deployment(name = "alternativeUiPathCollision")
+    @Deployment(name = "alternativeUiPathCollision", testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("alternativeUiPathCollision",
                 PlainUI.class, PlainColidingAlternativeUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingDeploymentTest.java
@@ -16,28 +16,26 @@
 
 package com.vaadin.cdi;
 
-import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.PlainColidingAlternativeUI;
+import com.vaadin.cdi.uis.PlainUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.cdi.uis.PlainColidingAlternativeUI;
-import com.vaadin.cdi.uis.PlainUI;
+import java.io.IOException;
+
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class CDIIntegrationWithConflictingDeploymentTest extends
         AbstractManagedCDIIntegrationTest {
 
     @Before
-    public void resetCounter() {
-        PlainUI.resetCounter();
-        PlainColidingAlternativeUI.resetCounter();
+    public void resetCounter() throws IOException {
+        resetCounts();
     }
 
     @Deployment(name = "alternativeUiPathCollision")
@@ -48,12 +46,12 @@ public class CDIIntegrationWithConflictingDeploymentTest extends
 
     @Test
     @OperateOnDeployment("alternativeUiPathCollision")
-    public void alternativeDoesNotColideWithPath() throws MalformedURLException {
+    public void alternativeDoesNotColideWithPath() throws IOException {
         final String plainUIPath = deriveMappingForUI(PlainUI.class);
         final String plainAlternativeUI = deriveMappingForUI(PlainColidingAlternativeUI.class);
         assertThat(plainUIPath, is(plainAlternativeUI));
         openWindow(plainUIPath);
-        assertThat(PlainUI.getNumberOfInstances(), is(1));
-        assertThat(PlainColidingAlternativeUI.getNumberOfInstances(), is(0));
+        assertThat(getCount(PlainUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(PlainColidingAlternativeUI.CONSTRUCT_COUNT), is(0));
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
@@ -2,13 +2,10 @@ package com.vaadin.cdi;
 
 import com.vaadin.cdi.uis.AnotherPathCollisionUI;
 import com.vaadin.cdi.uis.PathCollisionUI;
-import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-
-import java.net.MalformedURLException;
 
 import static org.junit.Assert.fail;
 
@@ -26,21 +23,11 @@ public class CDIIntegrationWithConflictingUIPathTest extends
      * Tests invalid deployment of multiple roots within a WAR Should be started
      * first -- Arquillian deployments are not perfectly isolated.
      */
-    @Test
+    @Test(expected = Exception.class)
     @InSequence(-2)
-    public void uiPathCollisionBreaksDeployment() throws MalformedURLException {
-        try {
-            System.out.println("DEPLOYING");
-            // Deployment doesn't declare that it can throw DeploymentException
-            // De-facto it can
-            deployer.deploy("uiPathCollision");
-            System.out.println("Deployed");
-            fail("Duplicate deployment paths should not be deployable");
-            throw new DeploymentException(null);
-        } catch (DeploymentException e) {
-            // Correct response
-            System.out.println("Exiting try block");
-        }
+    public void uiPathCollisionBreaksDeployment() throws Exception {
+        deployer.deploy("uiPathCollision");
+        fail("Duplicate deployment paths should not be deployable");
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
@@ -16,7 +16,7 @@ public class CDIIntegrationWithConflictingUIPathTest extends
         AbstractCDIIntegrationTest {
 
 
-    @Deployment(name = "uiPathCollision", managed = false)
+    @Deployment(name = "uiPathCollision", managed = false, testable = false)
     public static WebArchive multipleUIsWithSamePath() {
         return ArchiveProvider.createWebArchive("uiPathCollision",
                 PathCollisionUI.class, AnotherPathCollisionUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithConflictingUIPathTest.java
@@ -1,30 +1,20 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.AnotherPathCollisionUI;
+import com.vaadin.cdi.uis.PathCollisionUI;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.cdi.uis.AnotherPathCollisionUI;
-import com.vaadin.cdi.uis.PathCollisionUI;
-import com.vaadin.cdi.uis.RootUI;
+import java.net.MalformedURLException;
+
+import static org.junit.Assert.fail;
 
 public class CDIIntegrationWithConflictingUIPathTest extends
         AbstractCDIIntegrationTest {
 
-    @Before
-    public void resetCounter() {
-        PathCollisionUI.resetCounter();
-        AnotherPathCollisionUI.resetCounter();
-    }
 
     @Deployment(name = "uiPathCollision", managed = false)
     public static WebArchive multipleUIsWithSamePath() {
@@ -39,7 +29,6 @@ public class CDIIntegrationWithConflictingUIPathTest extends
     @Test
     @InSequence(-2)
     public void uiPathCollisionBreaksDeployment() throws MalformedURLException {
-        assertThat(RootUI.getNumberOfInstances(), is(0));
         try {
             System.out.println("DEPLOYING");
             // Deployment doesn't declare that it can throw DeploymentException
@@ -53,4 +42,5 @@ public class CDIIntegrationWithConflictingUIPathTest extends
             System.out.println("Exiting try block");
         }
     }
+
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithCustomDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithCustomDeploymentTest.java
@@ -16,25 +16,24 @@
 
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.CustomMappingUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.cdi.uis.CustomMappingUI;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class CDIIntegrationWithCustomDeploymentTest extends
         AbstractManagedCDIIntegrationTest {
 
     @Before
-    public void resetCounter() {
-        CustomMappingUI.resetCounter();
+    public void resetCounter() throws IOException {
+        resetCounts();
     }
 
     @Deployment(name = "customURIMapping")
@@ -45,9 +44,9 @@ public class CDIIntegrationWithCustomDeploymentTest extends
 
     @Test
     @OperateOnDeployment("customURIMapping")
-    public void customServletMapping() throws MalformedURLException {
-        assertThat(CustomMappingUI.getNumberOfInstances(), is(0));
+    public void customServletMapping() throws IOException {
+        assertThat(getCount(CustomMappingUI.CONSTRUCT_COUNT), is(0));
         openWindow("customURI/");
-        assertThat(CustomMappingUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(CustomMappingUI.CONSTRUCT_COUNT), is(1));
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithCustomDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithCustomDeploymentTest.java
@@ -36,7 +36,7 @@ public class CDIIntegrationWithCustomDeploymentTest extends
         resetCounts();
     }
 
-    @Deployment(name = "customURIMapping")
+    @Deployment(name = "customURIMapping", testable = false)
     public static WebArchive archiveWithCustomURIMapping() {
         return ArchiveProvider
                 .createWebArchive("custom", CustomMappingUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -17,9 +17,7 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.uis.*;
-import com.vaadin.cdi.views.ConventionalView;
-import com.vaadin.cdi.views.MainView;
-import com.vaadin.cdi.views.SubView;
+import com.vaadin.cdi.views.*;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
@@ -57,6 +55,7 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
                 Boundary.class, EnterpriseLabel.class, SubUI.class,
                 PlainAlternativeUI.class, NoViewProviderNavigationUI.class,
                 ConventionalView.class, MainView.class, SubView.class,
+                AbstractScopedInstancesView.class, AbstractNavigatableView.class,
                 NavigatableUI.class);
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -40,7 +40,7 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
         resetCounts();
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive archiveWithDefaultRootUI() {
         return ArchiveProvider.createWebArchive("default",
                 InstrumentedUI.class, InstrumentedView.class,

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -40,7 +40,6 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     @Before
     public void resetCounter() throws IOException {
         resetCounts();
-        ParameterizedNavigationUI.reset();
     }
 
     @Deployment
@@ -241,8 +240,8 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     public void navigationToRestrictedViewFails() throws IOException {
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
         assertThat(getCount(RestrictedView.CONSTRUCT_COUNT), is(0));
-        ParameterizedNavigationUI.NAVIGATE_TO = "restrictedView";
-        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
+        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class) +
+                ParameterizedNavigationUI.getNavigateToParam("restrictedView"));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));
         assertThat(getCount(RestrictedView.CONSTRUCT_COUNT), is(0));
@@ -299,8 +298,8 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     public void viewConventions() throws IOException {
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
         assertThat(getCount(ConventionalView.CONSTRUCT_COUNT), is(0));
-        ParameterizedNavigationUI.NAVIGATE_TO = "conventional";
-        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
+        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class) +
+                ParameterizedNavigationUI.getNavigateToParam("conventional"));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "conventional");
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -138,9 +138,9 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
 
     @Test
     public void rootUIDiscovery() throws IOException {
-        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(0));
+        assertThat(getCount(RootUI.CONSTRUCT_COUNT), is(0));
         openWindow("");
-        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(1));
+        assertThat(getCount(RootUI.CONSTRUCT_COUNT), is(1));
     }
 
     @Test

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -16,17 +16,10 @@
 
 package com.vaadin.cdi;
 
-import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.*;
+import com.vaadin.cdi.views.ConventionalView;
+import com.vaadin.cdi.views.MainView;
+import com.vaadin.cdi.views.SubView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
@@ -34,58 +27,20 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 
-import com.vaadin.cdi.uis.Boundary;
-import com.vaadin.cdi.uis.DanglingView;
-import com.vaadin.cdi.uis.DependentCDIEventListener;
-import com.vaadin.cdi.uis.EnterpriseLabel;
-import com.vaadin.cdi.uis.EnterpriseUI;
-import com.vaadin.cdi.uis.InstrumentedInterceptor;
-import com.vaadin.cdi.uis.InstrumentedUI;
-import com.vaadin.cdi.uis.InstrumentedView;
-import com.vaadin.cdi.uis.InterceptedBean;
-import com.vaadin.cdi.uis.InterceptedUI;
-import com.vaadin.cdi.uis.NavigatableUI;
-import com.vaadin.cdi.uis.NoViewProviderNavigationUI;
-import com.vaadin.cdi.uis.ParameterizedNavigationUI;
-import com.vaadin.cdi.uis.PlainAlternativeUI;
-import com.vaadin.cdi.uis.PlainUI;
-import com.vaadin.cdi.uis.RestrictedView;
-import com.vaadin.cdi.uis.RootUI;
-import com.vaadin.cdi.uis.ScopedInstrumentedView;
-import com.vaadin.cdi.uis.SecondUI;
-import com.vaadin.cdi.uis.SubUI;
-import com.vaadin.cdi.uis.UIWithCDIDependentListener;
-import com.vaadin.cdi.uis.UIWithCDISelfListener;
-import com.vaadin.cdi.uis.UnsecuredUI;
-import com.vaadin.cdi.uis.ViewWithoutAnnotation;
-import com.vaadin.cdi.uis.WithAnnotationRegisteredView;
-import com.vaadin.cdi.views.ConventionalView;
-import com.vaadin.cdi.views.MainView;
-import com.vaadin.cdi.views.SubView;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class CDIIntegrationWithDefaultDeploymentTest extends
         AbstractManagedCDIIntegrationTest {
 
     @Before
-    public void resetCounter() {
-        PlainUI.resetCounter();
-        PlainAlternativeUI.resetCounter();
-        InstrumentedUI.resetCounter();
-        InstrumentedView.resetCounter();
-        ScopedInstrumentedView.resetCounter();
-        ViewWithoutAnnotation.resetCounter();
-        WithAnnotationRegisteredView.resetCounter();
-        SecondUI.resetCounter();
-        RootUI.resetCounter();
-        UIWithCDIDependentListener.resetCounter();
-        UIWithCDISelfListener.resetCounter();
-        DependentCDIEventListener.resetCounter();
-        DependentCDIEventListener.resetEventCounter();
+    public void resetCounter() throws IOException {
+        resetCounts();
         ParameterizedNavigationUI.reset();
-        NoViewProviderNavigationUI.resetCounter();
-        InterceptedUI.resetCounter();
-        EnterpriseUI.resetCounter();
-
     }
 
     @Deployment
@@ -107,14 +62,14 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     }
 
     @Test
-    public void browserRestartCreatesNewInstance() throws MalformedURLException {
+    public void browserRestartCreatesNewInstance() throws Exception {
         String uri = deriveMappingForUI(PlainUI.class);
         openWindow(uri);
 
         // Throws exception if element not found
         firstWindow.findElement(LABEL);
 
-        assertThat(PlainUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(PlainUI.CONSTRUCT_COUNT), is(1));
 
         // reset session
         openWindow(uri);
@@ -122,183 +77,182 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
         // Throws exception if element not found
         firstWindow.findElement(LABEL);
 
-        assertThat(PlainUI.getNumberOfInstances(), is(2));
+        assertThat(getCount(PlainUI.CONSTRUCT_COUNT), is(2));
         assertDefaultRootNotInstantiated();
 
     }
 
     @Test
     public void oneToOneRelationBetweenBrowserAndUI()
-            throws MalformedURLException {
+            throws IOException {
 
         openWindow(INSTRUMENTED_UI_URI);
 
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, 1);
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(1));
 
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, 2);
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(1));
 
         openWindow(INSTRUMENTED_UI_URI);
 
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, 1);
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(2));
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(2));
 
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, 2);
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(2));
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(2));
         assertDefaultRootNotInstantiated();
     }
 
     @Test
     public void dependentScopedViewIsInstantiatedTwiceWithViewProvider()
-            throws MalformedURLException {
+            throws IOException {
         openWindow(firstWindow, INSTRUMENTED_VIEW_URI);
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "ViewLabel");
-        assertThat(InstrumentedView.getNumberOfInstances(), is(2));
+        assertThat(getCount(InstrumentedView.CONSTRUCT_COUNT), is(2));
     }
 
     @Test
     public void dependentScopedViewIsInstantiatedOnce()
-            throws MalformedURLException {
+            throws IOException {
         String uri = deriveMappingForUI(NoViewProviderNavigationUI.class);
         openWindow(uri);
-        assertThat(InstrumentedView.getNumberOfInstances(), is(1));
+        assertThat(getCount(InstrumentedView.CONSTRUCT_COUNT), is(1));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
 
         waitForValue(VIEW_LABEL, "ViewLabel");
-        assertThat(InstrumentedView.getNumberOfInstances(), is(1));
-        assertThat(NoViewProviderNavigationUI.getNumberOfInstances(), is(1));
-        assertThat(NoViewProviderNavigationUI.getNumberOfNavigations(), is(1));
+        assertThat(getCount(InstrumentedView.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(NoViewProviderNavigationUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(NoViewProviderNavigationUI.NAVIGATION_COUNT), is(1));
 
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "ViewLabel");
-        assertThat(InstrumentedView.getNumberOfInstances(), is(1));
-        assertThat(NoViewProviderNavigationUI.getNumberOfInstances(), is(1));
-        assertThat(NoViewProviderNavigationUI.getNumberOfNavigations(), is(2));
+        assertThat(getCount(InstrumentedView.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(NoViewProviderNavigationUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(NoViewProviderNavigationUI.NAVIGATION_COUNT), is(2));
 
     }
 
     @Test
-    public void rootUIDiscovery() throws MalformedURLException {
-        assertThat(RootUI.getNumberOfInstances(), is(0));
+    public void rootUIDiscovery() throws IOException {
+        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(0));
         openWindow("");
-        assertThat(RootUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(RootUI.CONSTRUCT_KEY), is(1));
     }
 
     @Test
-    public void uiInheritance() throws MalformedURLException {
+    public void uiInheritance() throws Exception {
         openWindow(deriveMappingForUI(SubUI.class));
-        assertThat(SubUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(PlainUI.CONSTRUCT_COUNT), is(1));
         assertDefaultRootNotInstantiated();
     }
 
     @Test
     public void refreshButtonCreatesNewUIInstance()
-            throws MalformedURLException {
+            throws IOException {
         openWindow(INSTRUMENTED_UI_URI);
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(1));
-        firstWindow.navigate().refresh();
-        assertThat(InstrumentedUI.getNumberOfInstances(), is(2));
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(1));
+        refreshWindow();
+        assertThat(getCount(InstrumentedUI.CONSTRUCT_COUNT), is(2));
         assertDefaultRootNotInstantiated();
     }
 
     @Test
-    public void danglingViewCauses404() throws MalformedURLException {
+    public void danglingViewCauses404() throws IOException {
         openWindow(DANGLING_VIEW_URI);
         firstWindow.findElement(NAVIGATE_BUTTON).click();
-        assertThat(SecondUI.getNumberOfInstances(), is(1));
-        assertThat(DanglingView.getNumberOfInstances(), is(0));
+        assertThat(getCount(SecondUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(DanglingView.CONSTRUCT_COUNT), is(0));
     }
 
     @Test
-    public void alternativeIsNotAccessible() throws MalformedURLException {
+    public void alternativeIsNotAccessible() throws IOException {
         openWindowNoWait(deriveMappingForUI(PlainAlternativeUI.class));
         final String expectedErrorMessage = firstWindow.getPageSource();
         assertThat(expectedErrorMessage, containsString("404"));
-        assertThat(PlainAlternativeUI.getNumberOfInstances(), is(0));
+        assertThat(getCount(PlainAlternativeUI.CONSTRUCT_COUNT), is(0));
     }
 
     @Test
     public void cdiEventsArrivesInTheSameUIScopedInstance()
-            throws MalformedURLException, InterruptedException {
-        assertThat(UIWithCDISelfListener.getNumberOfInstances(), is(0));
-        assertThat(UIWithCDISelfListener.getNumberOfDeliveredEvents(), is(0));
+            throws IOException, InterruptedException {
+        assertThat(getCount(UIWithCDISelfListener.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(UIWithCDISelfListener.EVENT_COUNT), is(0));
         
         openWindow(UIWithCDISelfListener.class);
         
         firstWindow.findElement(BUTTON).click();        
         waitForValue(By.id(UIWithCDISelfListener.MESSAGE_ID), "1 message");
-        assertThat(UIWithCDISelfListener.getNumberOfInstances(), is(1));
-        assertThat(UIWithCDISelfListener.getNumberOfDeliveredEvents(), is(1));
+        assertThat(getCount(UIWithCDISelfListener.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(UIWithCDISelfListener.EVENT_COUNT), is(1));
         
         firstWindow.findElement(BUTTON).click();
         waitForValue(By.id(UIWithCDISelfListener.MESSAGE_ID), "2 messages");
-        assertThat(UIWithCDISelfListener.getNumberOfInstances(), is(1));
-        assertThat(UIWithCDISelfListener.getNumberOfDeliveredEvents(), is(2));
+        assertThat(getCount(UIWithCDISelfListener.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(UIWithCDISelfListener.EVENT_COUNT), is(2));
 
     }
 
     @Test
     public void cdiEventsArrivesInDependentListener()
-            throws MalformedURLException, InterruptedException {
-        assertThat(UIWithCDIDependentListener.getNumberOfInstances(), is(0));
-        assertThat(DependentCDIEventListener.getNumberOfDeliveredEvents(),
-                is(0));
-        assertThat(DependentCDIEventListener.getNumberOfInstances(), is(0));
+            throws IOException, InterruptedException {
+        assertThat(getCount(UIWithCDIDependentListener.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(DependentCDIEventListener.EVENT_COUNT), is(0));
+        assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(0));
         String uri = deriveMappingForUI(UIWithCDIDependentListener.class);
         openWindow(uri);
         firstWindow.findElement(BUTTON).click();
         Thread.sleep(100);
-        assertThat(UIWithCDIDependentListener.getNumberOfInstances(), is(1));
-        assertThat(DependentCDIEventListener.getNumberOfInstances(), is(1));
-        assertThat(DependentCDIEventListener.getNumberOfDeliveredEvents(),
+        assertThat(getCount(UIWithCDIDependentListener.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(DependentCDIEventListener.EVENT_COUNT),
                 is(1));
         firstWindow.findElement(BUTTON).click();
         Thread.sleep(100);
-        assertThat(UIWithCDIDependentListener.getNumberOfInstances(), is(1));
-        assertThat(DependentCDIEventListener.getNumberOfInstances(), is(2));
-        assertThat(DependentCDIEventListener.getNumberOfDeliveredEvents(),
+        assertThat(getCount(UIWithCDIDependentListener.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(2));
+        assertThat(getCount(DependentCDIEventListener.EVENT_COUNT),
                 is(2));
 
     }
 
     @Test
-    public void interceptedScopedEventListener() throws MalformedURLException,
+    public void interceptedScopedEventListener() throws IOException,
             InterruptedException {
-        assertThat(InterceptedUI.getNumberOfInstances(), is(0));
-        assertThat(InstrumentedInterceptor.getCounter(), is(0));
+        assertThat(getCount(InterceptedUI.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(InstrumentedInterceptor.INTERCEPT_COUNT), is(0));
         String uri = deriveMappingForUI(InterceptedUI.class);
         openWindow(uri);
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, "hello from intercepted bean");
-        assertThat(InstrumentedInterceptor.getCounter(), is(1));
+        assertThat(getCount(InstrumentedInterceptor.INTERCEPT_COUNT), is(1));
         firstWindow.findElement(BUTTON).click();
         Thread.sleep(100);
-        assertThat(InstrumentedInterceptor.getCounter(), is(2));
+        assertThat(getCount(InstrumentedInterceptor.INTERCEPT_COUNT), is(2));
 
     }
 
     @Test
-    public void navigationToRestrictedViewFails() throws MalformedURLException {
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(0));
-        assertThat(RestrictedView.getNumberOfInstances(), is(0));
+    public void navigationToRestrictedViewFails() throws IOException {
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(RestrictedView.CONSTRUCT_COUNT), is(0));
         ParameterizedNavigationUI.NAVIGATE_TO = "restrictedView";
         openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(1));
-        assertThat(RestrictedView.getNumberOfInstances(), is(0));
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(RestrictedView.CONSTRUCT_COUNT), is(0));
         assertDefaultRootNotInstantiated();
     }
 
     @Test
-    public void ejbInvocation() throws MalformedURLException {
+    public void ejbInvocation() throws IOException {
         openWindow(deriveMappingForUI(EnterpriseUI.class));
-        assertThat(EnterpriseUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(EnterpriseUI.CONSTRUCT_COUNT), is(1));
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, "Echo: 1");
         final String labelText = firstWindow.findElement(LABEL).getText();
@@ -306,7 +260,7 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
         final String labelText2 = firstWindow.findElement(
                 By.id(EnterpriseLabel.ENTERPRISE_LABEL)).getText();
         assertThat(labelText2, startsWith("Echo:"));
-        assertThat(EnterpriseUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(EnterpriseUI.CONSTRUCT_COUNT), is(1));
         assertDefaultRootNotInstantiated();
     }
 
@@ -342,15 +296,15 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     }
 
     @Test
-    public void viewConventions() throws MalformedURLException {
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(0));
-        assertThat(ConventionalView.getNumberOfInstances(), is(0));
+    public void viewConventions() throws IOException {
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(ConventionalView.CONSTRUCT_COUNT), is(0));
         ParameterizedNavigationUI.NAVIGATE_TO = "conventional";
         openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "conventional");
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(1));
-        assertThat(ConventionalView.getNumberOfInstances(), is(1));
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(ConventionalView.CONSTRUCT_COUNT), is(1));
         assertDefaultRootNotInstantiated();
 
     }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -204,14 +204,12 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
         assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(0));
         String uri = deriveMappingForUI(UIWithCDIDependentListener.class);
         openWindow(uri);
-        firstWindow.findElement(BUTTON).click();
-        Thread.sleep(100);
+        clickAndWait(BUTTON);
         assertThat(getCount(UIWithCDIDependentListener.CONSTRUCT_COUNT), is(1));
         assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(1));
         assertThat(getCount(DependentCDIEventListener.EVENT_COUNT),
                 is(1));
-        firstWindow.findElement(BUTTON).click();
-        Thread.sleep(100);
+        clickAndWait(BUTTON);
         assertThat(getCount(UIWithCDIDependentListener.CONSTRUCT_COUNT), is(1));
         assertThat(getCount(DependentCDIEventListener.CONSTRUCT_COUNT), is(2));
         assertThat(getCount(DependentCDIEventListener.EVENT_COUNT),
@@ -229,8 +227,7 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
         firstWindow.findElement(BUTTON).click();
         waitForValue(LABEL, "hello from intercepted bean");
         assertThat(getCount(InstrumentedInterceptor.INTERCEPT_COUNT), is(1));
-        firstWindow.findElement(BUTTON).click();
-        Thread.sleep(100);
+        clickAndWait(BUTTON);
         assertThat(getCount(InstrumentedInterceptor.INTERCEPT_COUNT), is(2));
 
     }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CDIIntegrationWithDefaultDeploymentTest.java
@@ -172,7 +172,7 @@ public class CDIIntegrationWithDefaultDeploymentTest extends
     public void alternativeIsNotAccessible() throws IOException {
         openWindowNoWait(deriveMappingForUI(PlainAlternativeUI.class));
         final String expectedErrorMessage = firstWindow.getPageSource();
-        assertThat(expectedErrorMessage, containsString("404"));
+        assertThat(expectedErrorMessage, containsString("Request was not handled by any registered handler."));
         assertThat(getCount(PlainAlternativeUI.CONSTRUCT_COUNT), is(0));
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ConsistentInjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ConsistentInjectionTest.java
@@ -1,23 +1,22 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.internal.MyBean;
+import com.vaadin.cdi.uis.ConsistentInjectionUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.cdi.internal.Conventions;
-import com.vaadin.cdi.internal.MyBean;
-import com.vaadin.cdi.uis.ConsistentInjectionUI;
+import java.net.MalformedURLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class ConsistentInjectionTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "consistentInjection")
+    @Deployment(name = "consistentInjection", testable = false)
     public static WebArchive initAndPostConstructAreConsistent() {
         return ArchiveProvider.createWebArchive("consistentInjection",
                 ConsistentInjectionUI.class, MyBean.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CrossInjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CrossInjectionTest.java
@@ -19,7 +19,7 @@ import java.net.MalformedURLException;
 
 public class CrossInjectionTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "crossInjection")
+    @Deployment(name = "crossInjection", testable = false)
     public static WebArchive crossInjectionArchive() {
         return ArchiveProvider.createWebArchive("crossInjection",
                 ParameterizedNavigationUI.class, CrossInjectingView.class,

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CrossInjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CrossInjectionTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.cdi;
 
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
@@ -14,6 +15,8 @@ import com.vaadin.cdi.internal.CrossInjectingBean;
 import com.vaadin.cdi.uis.ParameterizedNavigationUI;
 import com.vaadin.cdi.views.CrossInjectingView;
 
+import java.net.MalformedURLException;
+
 public class CrossInjectionTest extends AbstractManagedCDIIntegrationTest {
 
     @Deployment(name = "crossInjection")
@@ -25,9 +28,9 @@ public class CrossInjectionTest extends AbstractManagedCDIIntegrationTest {
 
     @Test
     @OperateOnDeployment("crossInjection")
-    public void crossInjectionWithSetter() {
-        ParameterizedNavigationUI.NAVIGATE_TO = "";
-        openWindow(ParameterizedNavigationUI.class);
+    public void crossInjectionWithSetter() throws MalformedURLException {
+        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class) +
+                ParameterizedNavigationUI.getNavigateToParam(""));
         findElement("navigate").click();
         waitForValue(By.id("view"), "CrossInjectingView");
         String id1 = findElement(CrossInjectingView.TRUE_ID).getText();
@@ -38,9 +41,9 @@ public class CrossInjectionTest extends AbstractManagedCDIIntegrationTest {
 
     @Test
     @OperateOnDeployment("crossInjection")
-    public void crossInjectionWithConstructor() {
-        ParameterizedNavigationUI.NAVIGATE_TO = "";
-        openWindow(ParameterizedNavigationUI.class);
+    public void crossInjectionWithConstructor() throws MalformedURLException {
+        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class) +
+                ParameterizedNavigationUI.getNavigateToParam(""));
         findElement("navigate").click();
         waitForValue(By.id("view"), "CrossInjectingView");
         String id1 = findElement(CrossInjectingView.TRUE_ID).getText();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.fail;
 public class InappropriateCDIViewInDeploymentTest extends
         AbstractCDIIntegrationTest {
 
-    @Deployment(name = "cdiViewWithoutView", managed = false)
+    @Deployment(name = "cdiViewWithoutView", managed = false, testable = false)
     public static WebArchive multipleUIsWithSamePath() {
         return ArchiveProvider.createWebArchive("cdiViewWithoutView",
                 CDIViewNotImplementingView.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
@@ -1,13 +1,10 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.views.CDIViewNotImplementingView;
-import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-
-import java.net.MalformedURLException;
 
 import static org.junit.Assert.fail;
 
@@ -24,22 +21,11 @@ public class InappropriateCDIViewInDeploymentTest extends
      * Tests invalid deployment of multiple roots within a WAR Should be started
      * first -- Arquillian deployments are not perfectly isolated.
      */
-    @Test
+    @Test(expected = Exception.class)
     @InSequence(-2)
-    public void cdiViewWithoutViewBreaksDeployment()
-            throws MalformedURLException {
-        try {
-            System.out.println("DEPLOYING");
-            // Deployment doesn't declare that it can throw DeploymentException
-            // De-facto it can
-            deployer.deploy("cdiViewWithoutView");
-            System.out.println("Deployed");
-            fail("CDIView that does not implement View should not be deployable");
-            throw new DeploymentException(null);
-        } catch (DeploymentException e) {
-            // Correct response
-            System.out.println("Exiting try block");
-        }
+    public void cdiViewWithoutViewBreaksDeployment() throws Exception {
+        deployer.deploy("cdiViewWithoutView");
+        fail("CDIView that does not implement View should not be deployable");
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateCDIViewInDeploymentTest.java
@@ -1,16 +1,15 @@
 package com.vaadin.cdi;
 
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.views.CDIViewNotImplementingView;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 
-import com.vaadin.cdi.views.CDIViewNotImplementingView;
+import java.net.MalformedURLException;
+
+import static org.junit.Assert.fail;
 
 public class InappropriateCDIViewInDeploymentTest extends
         AbstractCDIIntegrationTest {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.fail;
 public class InappropriateNestedServletInDeploymentTest extends
         AbstractCDIIntegrationTest {
 
-    @Deployment(name = "nestedServlet", managed = false)
+    @Deployment(name = "nestedServlet", managed = false, testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("nestedServlet",
                 UIWithNestedServlet.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
@@ -16,17 +16,16 @@
 
 package com.vaadin.cdi;
 
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.UIWithNestedServlet;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 
-import com.vaadin.cdi.uis.UIWithNestedServlet;
+import java.net.MalformedURLException;
+
+import static org.junit.Assert.fail;
 
 public class InappropriateNestedServletInDeploymentTest extends
         AbstractCDIIntegrationTest {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InappropriateNestedServletInDeploymentTest.java
@@ -17,13 +17,10 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.uis.UIWithNestedServlet;
-import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-
-import java.net.MalformedURLException;
 
 import static org.junit.Assert.fail;
 
@@ -40,21 +37,11 @@ public class InappropriateNestedServletInDeploymentTest extends
      * Tests invalid deployment nested servlet within a UI class. Should be
      * started first -- Arquillian deployments are not perfectly isolated.
      */
-    @Test
+    @Test(expected = Exception.class)
     @InSequence(-2)
-    public void nestedServletBreaksDeployment() throws MalformedURLException {
-        try {
-            System.out.println("DEPLOYING");
-            // Deployment doesn't declare that it can throw DeploymentException
-            // De-facto it can
-            deployer.deploy("nestedServlet");
-            System.out.println("Deployed");
-            fail("Servlet class nested in the UI should not be deployable");
-            throw new DeploymentException(null);
-        } catch (DeploymentException e) {
-            // Correct response
-            System.out.println("Exiting try block");
-        }
+    public void nestedServletBreaksDeployment() throws Exception {
+        deployer.deploy("nestedServlet");
+        fail("Servlet class nested in the UI should not be deployable");
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InjectionTest.java
@@ -1,11 +1,9 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.internal.MyBean;
+import com.vaadin.cdi.uis.InjectionUI;
+import com.vaadin.cdi.views.BeanView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -14,14 +12,15 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.vaadin.cdi.internal.Conventions;
-import com.vaadin.cdi.internal.MyBean;
-import com.vaadin.cdi.uis.InjectionUI;
-import com.vaadin.cdi.views.BeanView;
+import java.net.MalformedURLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class InjectionTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "uiInjection")
+    @Deployment(name = "uiInjection", testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("uiInjection",
                 InjectionUI.class, MyBean.class, BeanView.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/InjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/InjectionTest.java
@@ -42,7 +42,7 @@ public class InjectionTest extends AbstractManagedCDIIntegrationTest {
 
         assertThat(bean11, is(bean21));
 
-        firstWindow.navigate().refresh();
+        refreshWindow();
 
         (new WebDriverWait(firstWindow, 15)).until(ExpectedConditions
                 .presenceOfElementLocated(By.id(InjectionUI.beanId1)));

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
@@ -26,7 +26,7 @@ public class MultipleAccessIsolationTest extends
         resetCounts();
     }
 
-    @Deployment(name = "concurrentAccess")
+    @Deployment(name = "concurrentAccess", testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("concurrentAccess",
                 ConcurrentUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
@@ -41,17 +41,19 @@ public class MultipleAccessIsolationTest extends
         assertThat(getCount(ConcurrentUI.CONSTRUCT_COUNT), is(1));
         firstWindow.findElement(By.id(ConcurrentUI.OPEN_WINDOW)).click();
         waitForNumberOfWindowsToEqual(2);
-        Thread.sleep(500);
         List<String> handles = new ArrayList<String>(
                 firstWindow.getWindowHandles());
+        // wait for second window fully loads
+        firstWindow.switchTo().window(handles.get(1));
+        (new WebDriverWait(firstWindow, 15)).until(ExpectedConditions
+                .presenceOfElementLocated(LABEL));
+
         firstWindow.switchTo().window(handles.get(0));
         firstWindow.findElement(By.id(ConcurrentUI.COUNTER_BUTTON)).click();
         firstWindow.findElement(By.id(ConcurrentUI.COUNTER_BUTTON)).click();
         firstWindow.findElement(By.id(ConcurrentUI.COUNTER_BUTTON)).click();
         waitForValue(By.id(ConcurrentUI.COUNTER_LABEL), 3);
         firstWindow.switchTo().window(handles.get(1));
-        (new WebDriverWait(firstWindow, 15)).until(ExpectedConditions
-                .presenceOfElementLocated(LABEL));
         // the second window was loaded before the clicks on the first one so
         // the counter is always 0
         assertThat(firstWindow.findElement(By.id(ConcurrentUI.COUNTER_LABEL))
@@ -68,8 +70,7 @@ public class MultipleAccessIsolationTest extends
         String uri = deriveMappingForUI(ConcurrentUI.class);
         assertThat(getCount(ConcurrentUI.CONSTRUCT_COUNT), is(0));
         openWindow(firstWindow, uri);
-        firstWindow.findElement(By.id(ConcurrentUI.COUNTER_BUTTON)).click();
-        Thread.sleep(100);
+        clickAndWait(ConcurrentUI.COUNTER_BUTTON);
         assertThat(firstWindow.findElement(By.id(ConcurrentUI.COUNTER_LABEL))
                 .getText(), is("1"));
         firstWindow.navigate().refresh();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleAccessIsolationTest.java
@@ -1,13 +1,6 @@
 package com.vaadin.cdi;
 
-import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.vaadin.cdi.uis.ConcurrentUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
@@ -17,14 +10,20 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.vaadin.cdi.uis.ConcurrentUI;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class MultipleAccessIsolationTest extends
         AbstractManagedCDIIntegrationTest {
 
     @Before
-    public void resetCounter() {
-        ConcurrentUI.resetCounter();
+    public void resetCounter() throws IOException {
+        resetCounts();
     }
 
     @Deployment(name = "concurrentAccess")
@@ -34,12 +33,12 @@ public class MultipleAccessIsolationTest extends
     }
 
     @Test
-    public void testConcurrentAccess() throws MalformedURLException,
+    public void testConcurrentAccess() throws IOException,
             InterruptedException {
         String uri = deriveMappingForUI(ConcurrentUI.class);
-        assertThat(ConcurrentUI.getNumberOfInstances(), is(0));
+        assertThat(getCount(ConcurrentUI.CONSTRUCT_COUNT), is(0));
         openWindow(firstWindow, uri);
-        assertThat(ConcurrentUI.getNumberOfInstances(), is(1));
+        assertThat(getCount(ConcurrentUI.CONSTRUCT_COUNT), is(1));
         firstWindow.findElement(By.id(ConcurrentUI.OPEN_WINDOW)).click();
         waitForNumberOfWindowsToEqual(2);
         Thread.sleep(500);
@@ -64,10 +63,10 @@ public class MultipleAccessIsolationTest extends
     }
 
     @Test
-    public void testConsecutiveAccess() throws MalformedURLException,
+    public void testConsecutiveAccess() throws IOException,
             InterruptedException {
         String uri = deriveMappingForUI(ConcurrentUI.class);
-        assertThat(ConcurrentUI.getNumberOfInstances(), is(0));
+        assertThat(getCount(ConcurrentUI.CONSTRUCT_COUNT), is(0));
         openWindow(firstWindow, uri);
         firstWindow.findElement(By.id(ConcurrentUI.COUNTER_BUTTON)).click();
         Thread.sleep(100);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.fail;
 @RunWith(Arquillian.class)
 public class MultipleRootUIsTest extends AbstractCDIIntegrationTest {
 
-    @Deployment(name = "multipleRoots", managed = false)
+    @Deployment(name = "multipleRoots", managed = false, testable = false)
     public static WebArchive archiveWithMultipleRoots() {
         return ArchiveProvider.createWebArchive("multipleRoots", RootUI.class,
                 CustomMappingUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
@@ -18,15 +18,12 @@ package com.vaadin.cdi;
 
 import com.vaadin.cdi.uis.CustomMappingUI;
 import com.vaadin.cdi.uis.RootUI;
-import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.MalformedURLException;
 
 import static org.junit.Assert.fail;
 
@@ -44,15 +41,10 @@ public class MultipleRootUIsTest extends AbstractCDIIntegrationTest {
      * Tests invalid deployment of multiple roots within a WAR Should be before
      * the regular tests -- Arquillian deployments are not perfectly isolated.
      */
-    @Test
-    public void multipleRootsBreakDeployment() throws MalformedURLException {
-        try {
-            deployer.deploy("multipleRoots");
-            fail("Multiple roots should not be deployable");
-            throw new DeploymentException(null);
-        } catch (DeploymentException e) {
-            // Correct response
-        }
+    @Test(expected = Exception.class)
+    public void multipleRootsBreakDeployment() throws Exception {
+        deployer.deploy("multipleRoots");
+        fail("Multiple roots should not be deployable");
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleRootUIsTest.java
@@ -16,31 +16,23 @@
 
 package com.vaadin.cdi;
 
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.CustomMappingUI;
+import com.vaadin.cdi.uis.RootUI;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.vaadin.cdi.uis.CustomMappingUI;
-import com.vaadin.cdi.uis.RootUI;
+import java.net.MalformedURLException;
+
+import static org.junit.Assert.fail;
 
 @RunAsClient
 @RunWith(Arquillian.class)
 public class MultipleRootUIsTest extends AbstractCDIIntegrationTest {
-
-    @Before
-    public void resetCounter() {
-        RootUI.resetCounter();
-        CustomMappingUI.resetCounter();
-    }
 
     @Deployment(name = "multipleRoots", managed = false)
     public static WebArchive archiveWithMultipleRoots() {
@@ -62,4 +54,5 @@ public class MultipleRootUIsTest extends AbstractCDIIntegrationTest {
             // Correct response
         }
     }
+
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleSessionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/MultipleSessionTest.java
@@ -1,11 +1,8 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.internal.MyBean;
+import com.vaadin.cdi.uis.MultipleSessionUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -14,13 +11,15 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.vaadin.cdi.internal.Conventions;
-import com.vaadin.cdi.internal.MyBean;
-import com.vaadin.cdi.uis.MultipleSessionUI;
+import java.net.MalformedURLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class MultipleSessionTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "multipleSessions")
+    @Deployment(name = "multipleSessions", testable = false)
     public static WebArchive injectedBeanDependsOnSession() {
         return ArchiveProvider.createWebArchive("multipleSessions",
                 MultipleSessionUI.class, MyBean.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/NonPassivatingBeanTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/NonPassivatingBeanTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import com.vaadin.cdi.internal.Conventions;
 import com.vaadin.cdi.internal.NonPassivatingBean;
+import com.vaadin.cdi.internal.ViewScopedContext;
 import com.vaadin.cdi.uis.NonPassivatingUI;
 import com.vaadin.cdi.views.NonPassivatingContentView;
 
@@ -20,7 +21,7 @@ public class NonPassivatingBeanTest extends AbstractManagedCDIIntegrationTest {
 
     
     
-    @Deployment(name = "nonPassivatingBean")
+    @Deployment(name = "nonPassivatingBean", testable = false)
     public static WebArchive nonPassivatingBeanArchive() {
         return ArchiveProvider.createWebArchive("nonPassivatingBean",
                 NonPassivatingBean.class, NonPassivatingUI.class, NonPassivatingContentView.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/QualifiedInjectionTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/QualifiedInjectionTest.java
@@ -1,27 +1,21 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.internal.*;
+import com.vaadin.cdi.uis.QualifierInjectionUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.cdi.internal.Alpha;
-import com.vaadin.cdi.internal.AlphaBean;
-import com.vaadin.cdi.internal.Beta;
-import com.vaadin.cdi.internal.BetaBean;
-import com.vaadin.cdi.internal.Conventions;
-import com.vaadin.cdi.internal.MyBean;
-import com.vaadin.cdi.uis.QualifierInjectionUI;
+import java.net.MalformedURLException;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 public class QualifiedInjectionTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "qualifiedInjection")
+    @Deployment(name = "qualifiedInjection", testable = false)
     public static WebArchive qualifiedInjectionArchive() {
         return ArchiveProvider.createWebArchive("qualifiedInjection",
                 QualifierInjectionUI.class, MyBean.class, AlphaBean.class,

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
@@ -21,7 +21,7 @@ public class RootViewAtContextRootTest extends AbstractManagedCDIIntegrationTest
         resetCounts();
     }
 
-    @Deployment(name = "rootView")
+    @Deployment(name = "rootView", testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("rootView", RootView.class,
                 ParameterizedNavigationUI.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
@@ -1,25 +1,24 @@
 package com.vaadin.cdi;
 
-import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.uis.ParameterizedNavigationUI;
+import com.vaadin.cdi.views.RootView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.cdi.uis.ParameterizedNavigationUI;
-import com.vaadin.cdi.views.RootView;
+import java.io.IOException;
+
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class RootViewAtContextRootTest extends AbstractManagedCDIIntegrationTest {
 
     @Before
-    public void resetCounter() {
-        RootView.reset();
+    public void resetCounter() throws IOException {
+        resetCounts();
     }
 
     @Deployment(name = "rootView")
@@ -30,14 +29,14 @@ public class RootViewAtContextRootTest extends AbstractManagedCDIIntegrationTest
 
     @Test
     @OperateOnDeployment("rootView")
-    public void testThatRootViewIsReachable() throws MalformedURLException {
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(0));
-        assertThat(RootView.getNumberOfInstances(), is(0));
+    public void testThatRootViewIsReachable() throws IOException {
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
+        assertThat(getCount(RootView.CONSTRUCT_COUNT), is(0));
         ParameterizedNavigationUI.NAVIGATE_TO = "";
         openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "default view");
-        assertThat(ParameterizedNavigationUI.getNumberOfInstances(), is(1));
-        assertThat(RootView.getNumberOfInstances(), is(1));
+        assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));
+        assertThat(getCount(RootView.CONSTRUCT_COUNT), is(1));
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/RootViewAtContextRootTest.java
@@ -32,8 +32,8 @@ public class RootViewAtContextRootTest extends AbstractManagedCDIIntegrationTest
     public void testThatRootViewIsReachable() throws IOException {
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(0));
         assertThat(getCount(RootView.CONSTRUCT_COUNT), is(0));
-        ParameterizedNavigationUI.NAVIGATE_TO = "";
-        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class));
+        openWindow(deriveMappingForUI(ParameterizedNavigationUI.class) +
+                ParameterizedNavigationUI.getNavigateToParam(""));
         firstWindow.findElement(NAVIGATE_BUTTON).click();
         waitForValue(VIEW_LABEL, "default view");
         assertThat(getCount(ParameterizedNavigationUI.CONSTRUCT_COUNT), is(1));

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ScopedInstancesTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ScopedInstancesTest.java
@@ -1,29 +1,28 @@
 package com.vaadin.cdi;
 
-import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-
+import com.vaadin.cdi.internal.UIScopedBean;
+import com.vaadin.cdi.internal.ViewScopedBean;
+import com.vaadin.cdi.uis.NavigatableUI;
+import com.vaadin.cdi.views.AbstractNavigatableView;
+import com.vaadin.cdi.views.AbstractScopedInstancesView;
+import com.vaadin.cdi.views.UIScopedView;
+import com.vaadin.cdi.views.ViewScopedView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.cdi.internal.UIScopedBean;
-import com.vaadin.cdi.internal.ViewScopedBean;
-import com.vaadin.cdi.uis.NavigatableUI;
-import com.vaadin.cdi.views.AbstractScopedInstancesView;
-import com.vaadin.cdi.views.AbstractNavigatableView;
-import com.vaadin.cdi.views.UIScopedView;
-import com.vaadin.cdi.views.ViewScopedView;
+import java.net.MalformedURLException;
+
+import static com.vaadin.cdi.internal.Conventions.deriveMappingForUI;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class ScopedInstancesTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "scopedNavigation")
+    @Deployment(name = "scopedNavigation", testable = false)
     public static WebArchive alternativeAndActiveWithSamePath() {
         return ArchiveProvider.createWebArchive("scopedNavigation",
                 UIScopedView.class, AbstractScopedInstancesView.class,

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ScopedProducerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ScopedProducerTest.java
@@ -1,13 +1,7 @@
 package com.vaadin.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-
+import com.vaadin.cdi.internal.ProducedBean;
+import com.vaadin.cdi.uis.ProducerUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -15,12 +9,15 @@ import org.junit.Test;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.vaadin.cdi.internal.ProducedBean;
-import com.vaadin.cdi.uis.ProducerUI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 
 public class ScopedProducerTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "scopedProducer")
+    @Deployment(name = "scopedProducer", testable = false)
     public static WebArchive scopedProducerArchive() {
         return ArchiveProvider.createWebArchive("scopedProducer",
                 ProducerUI.class, ProducedBean.class);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/Counter.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/Counter.java
@@ -1,0 +1,24 @@
+package com.vaadin.cdi.internal;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ApplicationScoped
+public class Counter {
+    ConcurrentHashMap<String, AtomicInteger> map = new ConcurrentHashMap<String, AtomicInteger>();
+
+    public void increment(String key) {
+        map.putIfAbsent(key, new AtomicInteger(0));
+        map.get(key).incrementAndGet();
+    }
+
+    public int get(String key) {
+        map.putIfAbsent(key, new AtomicInteger(0));
+        return map.get(key).get();
+    }
+
+    public void reset() {
+        map.clear();
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/Counter.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/Counter.java
@@ -8,9 +8,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class Counter {
     ConcurrentHashMap<String, AtomicInteger> map = new ConcurrentHashMap<String, AtomicInteger>();
 
-    public void increment(String key) {
+    public int increment(String key) {
         map.putIfAbsent(key, new AtomicInteger(0));
-        map.get(key).incrementAndGet();
+        return map.get(key).incrementAndGet();
     }
 
     public int get(String key) {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/CounterFilter.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/CounterFilter.java
@@ -1,0 +1,35 @@
+package com.vaadin.cdi.internal;
+
+import javax.inject.Inject;
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import java.io.IOException;
+
+@WebFilter(urlPatterns = "/*", asyncSupported = true)
+public class CounterFilter implements javax.servlet.Filter {
+
+    @Inject
+    Counter counter;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request.getParameter("resetCounts") != null) {
+            counter.reset();
+        } else {
+            String key = request.getParameter("getCount");
+            if (key != null) {
+                response.getWriter().println(counter.get(key));
+            } else {
+                chain.doFilter(request, response);
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/MyBean.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/MyBean.java
@@ -1,7 +1,6 @@
 package com.vaadin.cdi.internal;
 
 import com.vaadin.cdi.NormalUIScoped;
-import com.vaadin.ui.UI;
 
 @NormalUIScoped
 public class MyBean {
@@ -10,7 +9,6 @@ public class MyBean {
     private final int id = counter++;
 
     public MyBean() {
-        System.out.println(UI.getCurrent());
         System.out.println("Created MyBean with id " + id);
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/ProducedBean.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/internal/ProducedBean.java
@@ -1,7 +1,9 @@
 package com.vaadin.cdi.internal;
 
+import javax.enterprise.inject.Typed;
 import java.util.concurrent.atomic.AtomicLong;
 
+@Typed()
 public class ProducedBean {
     private static final AtomicLong counter = new AtomicLong(0);
     private final long id = counter.incrementAndGet();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
@@ -85,9 +85,7 @@ public class ShiroTest extends AbstractManagedCDIIntegrationTest {
     }
 
     private void checkThatViewDisallowed(String viewString) {
-        findElement(viewString).click();
-        // make sure the view does not change
-        sleep(2000);
+        clickAndWait(viewString);
         String viewAfterClick = findElement(AbstractShiroTestView.LABEL_ID)
                 .getText();
         assertThat(viewString, not(viewAfterClick));
@@ -98,7 +96,7 @@ public class ShiroTest extends AbstractManagedCDIIntegrationTest {
         waitForValue(By.id(AbstractShiroTestView.LABEL_ID), "Guest view");
         findElement(LoginPane.USER_ID).sendKeys(user);
         findElement(LoginPane.PASSWORD_ID).sendKeys(password);
-        findElement(LoginPane.LOGIN_ID).click();
+        clickAndWait(LoginPane.LOGIN_ID);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
@@ -1,8 +1,9 @@
 package com.vaadin.cdi.shiro;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-
+import com.vaadin.cdi.AbstractManagedCDIIntegrationTest;
+import com.vaadin.cdi.ArchiveProvider;
+import com.vaadin.cdi.uis.NavigatableUI;
+import com.vaadin.cdi.views.AbstractNavigatableView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -14,10 +15,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.cdi.AbstractManagedCDIIntegrationTest;
-import com.vaadin.cdi.ArchiveProvider;
-import com.vaadin.cdi.uis.NavigatableUI;
-import com.vaadin.cdi.views.AbstractNavigatableView;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 /**
  * Simple test of Shiro access control.
@@ -25,7 +24,7 @@ import com.vaadin.cdi.views.AbstractNavigatableView;
 @Ignore("See issue #186")
 public class ShiroTest extends AbstractManagedCDIIntegrationTest {
 
-    @Deployment(name = "shiro")
+    @Deployment(name = "shiro", testable = false)
     public static WebArchive initAndPostConstructAreConsistent() {
         PomEquippedResolveStage pom = Maven.resolver()
                 .loadPomFromFile("pom.xml");

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/AnotherPathCollisionUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/AnotherPathCollisionUI.java
@@ -22,22 +22,8 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import java.util.concurrent.atomic.AtomicInteger;
-
 @CDIUI("collision")
 public class AnotherPathCollisionUI extends UI {
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-        this.clickCount = 0;
-
-    }
 
     @Override
     protected void init(VaadinRequest request) {
@@ -50,14 +36,6 @@ public class AnotherPathCollisionUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ConcurrentUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ConcurrentUI.java
@@ -1,21 +1,17 @@
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.BrowserWindowOpener;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinSession;
-import com.vaadin.ui.Button;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.Layout;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 @CDIUI
 public class ConcurrentUI extends UI {
@@ -25,26 +21,17 @@ public class ConcurrentUI extends UI {
     public static final String COUNTER_LABEL = "counter-label";
     public static final String KILL_SESSION = "kill-session";
     public static final String OPEN_WINDOW = "open-window";
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-
+    public static final String CONSTRUCT_COUNT = "ConcurrentUIConstruct";
     private int clickCount;
 
-    private int instanceClicks = 0;
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
         clickCount = 0;
 
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
     @Override

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ConflictingRootUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ConflictingRootUI.java
@@ -16,10 +16,6 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
@@ -30,15 +26,6 @@ import com.vaadin.ui.VerticalLayout;
  */
 @CDIUI("")
 public class ConflictingRootUI extends UI {
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
-    }
 
     @Override
     protected void init(VaadinRequest request) {
@@ -53,11 +40,4 @@ public class ConflictingRootUI extends UI {
         setContent(layout);
     }
 
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
-    }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/CustomMappingUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/CustomMappingUI.java
@@ -16,30 +16,30 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.URLMapping;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 /**
  */
 @CDIUI("")
 @URLMapping("/customURI/*")
 public class CustomMappingUI extends UI {
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+
+    public static final String CONSTRUCT_COUNT = "CustomMappingUIConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -53,13 +53,5 @@ public class CustomMappingUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DanglingView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DanglingView.java
@@ -16,27 +16,29 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIView;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 /**
  */
 @CDIView(value = "danglingView", uis = { NotExistingUI.class })
 public class DanglingView extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "DanglingViewConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
 
     }
 
@@ -48,14 +50,6 @@ public class DanglingView extends CustomComponent implements View {
         Label label = new Label("ViewLabel");
         label.setId("label");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DependentCDIEventListener.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DependentCDIEventListener.java
@@ -16,42 +16,31 @@
 
 package com.vaadin.cdi.uis;
 
-import java.io.Serializable;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.vaadin.cdi.internal.Counter;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.io.Serializable;
 
 public class DependentCDIEventListener implements Serializable {
 
-    private final static AtomicInteger EVENT_COUNTER = new AtomicInteger(0);
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "DependentCDIEventListenerConstruct";
+    public static final String EVENT_COUNT = "DependentCDIEventListenerEvent";
+
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
-    public void onEventArrival(@Observes
-    String message) {
-        EVENT_COUNTER.incrementAndGet();
+
+    public void onEventArrival(@Observes String message) {
+        counter.increment(EVENT_COUNT);
         System.out.println("+DependentCDIEventListener Message arrived!");
     }
 
-    public static int getNumberOfDeliveredEvents() {
-        return EVENT_COUNTER.get();
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
-    }
-
-    public static void resetEventCounter() {
-        EVENT_COUNTER.set(0);
-    }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/EnterpriseUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/EnterpriseUI.java
@@ -16,22 +16,21 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI(value = "enterpriseUI")
 public class EnterpriseUI extends UI {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "EnterpriseUIConstruct";
     private int clickCount;
 
     @Inject
@@ -40,11 +39,13 @@ public class EnterpriseUI extends UI {
     @Inject
     private EnterpriseLabel injectedLabel;
 
+    @Inject
+    Counter counter;
+
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
         clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -69,14 +70,6 @@ public class EnterpriseUI extends UI {
         layout.addComponent(button);
         layout.addComponent(injectedLabel);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InjectionUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InjectionUI.java
@@ -3,7 +3,6 @@ package com.vaadin.cdi.uis;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.vaadin.annotations.Theme;
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.views.BeanView;
 import com.vaadin.server.VaadinRequest;
@@ -11,7 +10,6 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
-@Theme("reindeer")
 @CDIUI("")
 public class InjectionUI extends UI {
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedInterceptor.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedInterceptor.java
@@ -16,8 +16,9 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import com.vaadin.cdi.internal.Counter;
 
+import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
 
@@ -25,23 +26,16 @@ import javax.interceptor.InvocationContext;
  */
 public class InstrumentedInterceptor {
 
-    private final static AtomicInteger INTERCEPTION_COUNTER = new AtomicInteger(
-            0);
+    public static final String INTERCEPT_COUNT = "InstrumentedInterceptor";
+    @Inject
+    Counter counter;
 
     @AroundInvoke
     public Object intercept(InvocationContext invocationContext)
             throws Exception {
         System.out.println("---invoked: " + invocationContext.getMethod());
-        INTERCEPTION_COUNTER.incrementAndGet();
+        counter.increment(INTERCEPT_COUNT);
         return invocationContext.proceed();
 
-    }
-
-    public static int getCounter() {
-        return INTERCEPTION_COUNTER.get();
-    }
-
-    public static void reset() {
-        INTERCEPTION_COUNTER.set(0);
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedUI.java
@@ -16,13 +16,9 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.CDIViewProvider;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.Navigator;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
@@ -30,25 +26,29 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI(value = "instrumentedUI")
 public class InstrumentedUI extends UI {
 
+    public static final String CONSTRUCT_COUNT = "InstrumentedUIConstruct";
     @Inject
     InstrumentedView view;
 
     @Inject
     CDIViewProvider viewProvider;
 
+    @Inject
+    Counter counter;
+
     private Navigator navigator;
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
     private int clickCount;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -80,14 +80,6 @@ public class InstrumentedUI extends UI {
         layout.addComponent(button);
         layout.addComponent(navigate);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InstrumentedView.java
@@ -16,17 +16,17 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-
 import com.vaadin.cdi.CDIView;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 /**
  */
@@ -34,11 +34,13 @@ import com.vaadin.ui.VerticalLayout;
 @Dependent
 public class InstrumentedView extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "InstrumentedViewConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
 
     }
 
@@ -50,14 +52,6 @@ public class InstrumentedView extends CustomComponent implements View {
         Label label = new Label("ViewLabel");
         label.setId("view");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InterceptedUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/InterceptedUI.java
@@ -16,31 +16,32 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
 @CDIUI(value = "interceptedUI")
 public class InterceptedUI extends UI {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private final static AtomicInteger EVENT_COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "InterceptedUIConstruct";
 
     @Inject
     InterceptedBean interceptedBean;
 
+    @Inject
+    Counter counter;
+
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -64,18 +65,8 @@ public class InterceptedUI extends UI {
         setContent(layout);
     }
 
-    public void onEventArrival(@Observes
-    String message) {
-        EVENT_COUNTER.incrementAndGet();
+    public void onEventArrival(@Observes String message) {
         System.out.println("Message arrived!");
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/NoViewProviderNavigationUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/NoViewProviderNavigationUI.java
@@ -16,31 +16,28 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.*;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.vaadin.cdi.CDIUI;
-import com.vaadin.navigator.Navigator;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
-
 @CDIUI(value = "noViewProviderNavigationUI")
 public class NoViewProviderNavigationUI extends UI {
 
+    public static final String CONSTRUCT_COUNT = "NoViewProviderNavigationUIConstruct";
+    public static final String NAVIGATION_COUNT = "NoViewProviderNavigationUINavigation";
     @Inject
     InstrumentedView view;
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private final static AtomicInteger NAVIGATION_COUNTER = new AtomicInteger(0);
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -58,7 +55,7 @@ public class NoViewProviderNavigationUI extends UI {
         Button navigate = new Button("Navigate", new Button.ClickListener() {
             @Override
             public void buttonClick(Button.ClickEvent clickEvent) {
-                NAVIGATION_COUNTER.incrementAndGet();
+                counter.increment(NAVIGATION_COUNT);
                 Navigator navigator = new Navigator(
                         NoViewProviderNavigationUI.this, horizontalLayout);
                 navigator.addView("instrumentedView", view);
@@ -70,19 +67,6 @@ public class NoViewProviderNavigationUI extends UI {
         verticalLayout.addComponent(navigate);
         verticalLayout.addComponent(horizontalLayout);
         setContent(verticalLayout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static int getNumberOfNavigations() {
-        return NAVIGATION_COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
-        NAVIGATION_COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ParameterizedNavigationUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ParameterizedNavigationUI.java
@@ -35,7 +35,6 @@ public class ParameterizedNavigationUI extends UI {
     public static final String CONSTRUCT_COUNT = "ParameterizedNavigationUIConstruct";
     @Inject
     CDIViewProvider viewProvider;
-    public static String NAVIGATE_TO = "";
 
     @Inject
     Counter counter;
@@ -47,6 +46,7 @@ public class ParameterizedNavigationUI extends UI {
 
     @Override
     protected void init(VaadinRequest request) {
+        final String navigateTo = request.getParameter("navigateTo");
         setSizeFull();
 
         final VerticalLayout layout = new VerticalLayout();
@@ -60,7 +60,7 @@ public class ParameterizedNavigationUI extends UI {
                 Navigator navigator = new Navigator(
                         ParameterizedNavigationUI.this, layout);
                 navigator.addProvider(viewProvider);
-                navigator.navigateTo(NAVIGATE_TO);
+                navigator.navigateTo(navigateTo);
             }
         });
         navigate.setId("navigate");
@@ -68,8 +68,9 @@ public class ParameterizedNavigationUI extends UI {
         layout.addComponent(navigate);
         setContent(layout);
     }
-    public static void reset() {
-        NAVIGATE_TO = null;
+
+    public static String getNavigateToParam(String navigateTo) {
+        return "?navigateTo="+navigateTo;
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ParameterizedNavigationUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ParameterizedNavigationUI.java
@@ -16,13 +16,9 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.CDIViewProvider;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.Navigator;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
@@ -30,21 +26,23 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI(value = "parameterizedNavigationUI")
 public class ParameterizedNavigationUI extends UI {
 
+    public static final String CONSTRUCT_COUNT = "ParameterizedNavigationUIConstruct";
     @Inject
     CDIViewProvider viewProvider;
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
     public static String NAVIGATE_TO = "";
-    private int clickCount;
+
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -70,14 +68,8 @@ public class ParameterizedNavigationUI extends UI {
         layout.addComponent(navigate);
         setContent(layout);
     }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
     public static void reset() {
         NAVIGATE_TO = null;
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PathCollisionUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PathCollisionUI.java
@@ -22,22 +22,8 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import java.util.concurrent.atomic.AtomicInteger;
-
 @CDIUI("collision")
 public class PathCollisionUI extends UI {
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-        this.clickCount = 0;
-
-    }
 
     @Override
     protected void init(VaadinRequest request) {
@@ -50,14 +36,6 @@ public class PathCollisionUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainAlternativeUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainAlternativeUI.java
@@ -15,29 +15,27 @@
  */
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.inject.Alternative;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
 @CDIUI(value = "plainAlternativeUI")
 @Alternative
 public class PlainAlternativeUI extends UI {
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+    public static final String CONSTRUCT_COUNT = "PlainAlternativeUIConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -51,13 +49,5 @@ public class PlainAlternativeUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainColidingAlternativeUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainColidingAlternativeUI.java
@@ -16,29 +16,27 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.inject.Alternative;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
 @Alternative
 @CDIUI("PlainUI")
 public class PlainColidingAlternativeUI extends UI {
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+    public static final String CONSTRUCT_COUNT = "PlainColidingAlternativeUIConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -52,14 +50,6 @@ public class PlainColidingAlternativeUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/PlainUI.java
@@ -16,27 +16,26 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI("PlainUI")
 public class PlainUI extends UI {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+    public static final String CONSTRUCT_COUNT = "PlainUIConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -49,14 +48,6 @@ public class PlainUI extends UI {
         label.setId("label");
         layout.addComponent(label);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RestrictedView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RestrictedView.java
@@ -16,28 +16,29 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIView;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 /**
  */
 @CDIView(value = "restrictedView", uis = { SecondUI.class })
 public class RestrictedView extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "RestrictedViewConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -48,14 +49,6 @@ public class RestrictedView extends CustomComponent implements View {
         Label label = new Label("RestrictedView");
         label.setId("label");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RootUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RootUI.java
@@ -16,28 +16,27 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 /**
  */
 @CDIUI("")
 public class RootUI extends UI {
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+    public static final String CONSTRUCT_KEY = "RootUIConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_KEY);
     }
 
     @Override
@@ -53,11 +52,4 @@ public class RootUI extends UI {
         setContent(layout);
     }
 
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
-    }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RootUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/RootUI.java
@@ -30,13 +30,13 @@ import javax.inject.Inject;
  */
 @CDIUI("")
 public class RootUI extends UI {
-    public static final String CONSTRUCT_KEY = "RootUIConstruct";
+    public static final String CONSTRUCT_COUNT = "RootUIConstruct";
     @Inject
     Counter counter;
 
     @PostConstruct
     public void initialize() {
-        counter.increment(CONSTRUCT_KEY);
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ScopedInstrumentedView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ScopedInstrumentedView.java
@@ -16,10 +16,6 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIView;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
@@ -32,14 +28,6 @@ import com.vaadin.ui.VerticalLayout;
 @CDIView(value = "scopedInstrumentedView")
 public class ScopedInstrumentedView extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-
-    }
-
     @Override
     public void enter(ViewChangeEvent event) {
         VerticalLayout layout = new VerticalLayout();
@@ -48,14 +36,6 @@ public class ScopedInstrumentedView extends CustomComponent implements View {
         Label label = new Label("ViewLabel");
         label.setId("label");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/SecondUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/SecondUI.java
@@ -16,13 +16,9 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
 import com.vaadin.cdi.CDIViewProvider;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.Navigator;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
@@ -30,23 +26,26 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI(value = "secondUI")
 public class SecondUI extends UI {
 
+    public static final String CONSTRUCT_COUNT = "SecondUIConstruct";
     @Inject
     CDIViewProvider viewProvider;
 
     private Navigator navigator;
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private int clickCount;
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
-        clickCount = 0;
-
+        counter.increment(CONSTRUCT_COUNT);
     }
+
 
     @Override
     protected void init(VaadinRequest request) {
@@ -69,14 +68,6 @@ public class SecondUI extends UI {
         layout.addComponent(label);
         layout.addComponent(navigate);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/UIWithCDIDependentListener.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/UIWithCDIDependentListener.java
@@ -16,29 +16,29 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIUI(value = "uIWithCDIDependentListener")
 public class UIWithCDIDependentListener extends UI {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-
+    public static final String CONSTRUCT_COUNT = "UIWithCDIDependentListenerConstruct";
     @Inject
     private javax.enterprise.event.Event<String> events;
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -60,14 +60,6 @@ public class UIWithCDIDependentListener extends UI {
         layout.addComponent(label);
         layout.addComponent(button);
         setContent(layout);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/UIWithCDISelfListener.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/UIWithCDISelfListener.java
@@ -16,34 +16,35 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
 @CDIUI(value = "uIWithCDISelfListener")
 public class UIWithCDISelfListener extends UI {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-    private final static AtomicInteger EVENT_COUNTER = new AtomicInteger(0);
-
+    public static final String CONSTRUCT_COUNT = "UIWithCDISelfListenerConstruct";
+    public static final String EVENT_COUNT = "UIWithCDISelfListenerEvent";
     private Label messageLabel = new Label("No messages.");
     public static final String MESSAGE_ID = "message";
     
     @Inject
     private javax.enterprise.event.Event<String> events;
 
+    @Inject
+    Counter counter;
+
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -71,23 +72,10 @@ public class UIWithCDISelfListener extends UI {
         setContent(layout);
     }
 
-    public void onEventArrival(@Observes
-    String message) {
-        int count = EVENT_COUNTER.incrementAndGet();
+    public void onEventArrival(@Observes String message) {
+        int count = counter.increment(EVENT_COUNT);
         messageLabel.setValue(count + " message" + (count != 1 ? "s" : ""));
     }
 
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static int getNumberOfDeliveredEvents() {
-        return EVENT_COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
-        EVENT_COUNTER.set(0);
-    }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ViewWithoutAnnotation.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/ViewWithoutAnnotation.java
@@ -16,10 +16,6 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.CustomComponent;
@@ -30,14 +26,6 @@ import com.vaadin.ui.VerticalLayout;
  */
 public class ViewWithoutAnnotation extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-
-    }
-
     @Override
     public void enter(ViewChangeEvent event) {
         VerticalLayout layout = new VerticalLayout();
@@ -46,14 +34,6 @@ public class ViewWithoutAnnotation extends CustomComponent implements View {
         Label label = new Label("ViewLabel");
         label.setId("label");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/WithAnnotationRegisteredView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/WithAnnotationRegisteredView.java
@@ -16,10 +16,6 @@
 
 package com.vaadin.cdi.uis;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIView;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
@@ -30,16 +26,7 @@ import com.vaadin.ui.VerticalLayout;
 /**
  */
 @CDIView(value = "withAnnotationRegisteredView")
-public class WithAnnotationRegisteredView extends CustomComponent implements
-        View {
-
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
-
-    @PostConstruct
-    public void initialize() {
-        COUNTER.incrementAndGet();
-
-    }
+public class WithAnnotationRegisteredView extends CustomComponent implements View {
 
     @Override
     public void enter(ViewChangeEvent event) {
@@ -49,14 +36,6 @@ public class WithAnnotationRegisteredView extends CustomComponent implements
         Label label = new Label("ViewLabel");
         label.setId("label");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void resetCounter() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/views/ConventionalView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/views/ConventionalView.java
@@ -1,11 +1,7 @@
 package com.vaadin.cdi.views;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-
 import com.vaadin.cdi.CDIView;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.cdi.uis.ParameterizedNavigationUI;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
@@ -13,14 +9,21 @@ import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
 @CDIView(uis = { ParameterizedNavigationUI.class })
 @Dependent
 public class ConventionalView extends CustomComponent implements View {
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+
+    public static final String CONSTRUCT_COUNT = "ConventionalViewConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
 
     @Override
@@ -31,14 +34,6 @@ public class ConventionalView extends CustomComponent implements View {
         Label label = new Label("conventional");
         label.setId("view");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void reset() {
-        COUNTER.set(0);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/views/RootView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/views/RootView.java
@@ -1,25 +1,28 @@
 package com.vaadin.cdi.views;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PostConstruct;
-
 import com.vaadin.cdi.CDIView;
+import com.vaadin.cdi.internal.Counter;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 @CDIView("")
 public class RootView extends CustomComponent implements View {
 
-    private final static AtomicInteger COUNTER = new AtomicInteger(0);
+    public static final String CONSTRUCT_COUNT = "RootViewConstruct";
+    @Inject
+    Counter counter;
 
     @PostConstruct
     public void initialize() {
-        COUNTER.incrementAndGet();
+        counter.increment(CONSTRUCT_COUNT);
     }
+
     @Override
     public void enter(ViewChangeEvent event) {
         VerticalLayout layout = new VerticalLayout();
@@ -28,14 +31,6 @@ public class RootView extends CustomComponent implements View {
         Label label = new Label("default view");
         label.setId("view");
         layout.addComponent(label);
-    }
-
-    public static int getNumberOfInstances() {
-        return COUNTER.get();
-    }
-
-    public static void reset() {
-        COUNTER.set(0);
     }
 
 }


### PR DESCRIPTION
changes:
- Multiple tests tried to keep synchronized with client side using Thread.sleep. I've introduced a simple way to wait for vaadin client side using testbench javascript hook. Just to be clear: no testbench dependencies introduced. The hook exists in vaadin client.
-  Converted all tests to run as client. There were many static member accesses to the deployed classes ( mostly counters ) by the test. The main reason is embedded wildfly don't work with vaadin.  For some reason wildfly arquillian use a servlet even in embedded mode. Vaadin cdi deploys the servlet at /* knocking out the wildfly arquillian servlet. Maybe there is a solution, but never mind. Manged tests are always better than embedded. 
- Added glassfish, and wildfly managed arquillian test profiles. Some minor arquillian, and drone version upgrades also happened. Didn't touch tomee profile, it's still embedded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/183)
<!-- Reviewable:end -->
