### PR TITLE
fix ignored ShiroTest

### DIFF
--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/GuestView.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/GuestView.java
@@ -16,7 +16,7 @@ public class GuestView extends AbstractShiroTestView {
         label.setId(LABEL_ID);
         
         VerticalLayout layout = new VerticalLayout(label, new LoginPane());
-        layout.setSizeUndefined();
+        layout.setSizeFull();
         return layout;
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/LoginPane.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/LoginPane.java
@@ -25,7 +25,7 @@ public class LoginPane extends VerticalLayout {
     private Button loginButton = new Button("Login");
 
     public LoginPane() {
-        setSizeUndefined();
+        setSizeFull();
 
         currentUserLabel.setCaption("Current user:");
         currentUserLabel.setId(CURRENT_USER_ID);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/shiro/ShiroTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 /**
  * Simple test of Shiro access control.
  */
-@Ignore("See issue #186")
 public class ShiroTest extends AbstractManagedCDIIntegrationTest {
 
     @Deployment(name = "shiro", testable = false)


### PR DESCRIPTION
The test worked fine on firefox, and chrome, but failed on phantomjs. 
Upgrading phantomjsdriver to 1.3.0 does not help.
Workaround was to change LoginPane, and enclosing view to full-Sized. 
Related issue #186 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/192)
<!-- Reviewable:end -->
