### PR TITLE
fix bean destroy for UI and View context

### DIFF
--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -252,6 +252,7 @@
                             <systemPropertyVariables>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <jboss.home>${project.build.directory}/wildfly-10.1.0.Final</jboss.home>
+                                <arquillian.launch>wildfly</arquillian.launch>
                             </systemPropertyVariables>
                             <redirectTestOutputToFile>false</redirectTestOutputToFile>
                         </configuration>

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AbstractVaadinContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AbstractVaadinContext.java
@@ -204,12 +204,12 @@ public abstract class AbstractVaadinContext extends AbstractContext {
     private synchronized void dropUIData(SessionData sessionData, int uiId) {
         getLogger().fine("Dropping UI data for UI: " + uiId);
 
-        for (Entry<Contextual<?>, ContextualStorage> entry : new ArrayList<Entry<Contextual<?>, ContextualStorage>>(
-                sessionData.getStorageMap().entrySet())) {
-            Contextual<?> key = entry.getKey();
-            if (key instanceof UIContextual
-                    && ((UIContextual) key).getUiId() == uiId) {
-                destroy(entry.getKey());
+        Map<Contextual<?>, ContextualStorage> storageMap = sessionData.getStorageMap();
+        for (Contextual<?> contextual : new ArrayList<>(storageMap.keySet())) {
+            if (contextual instanceof UIContextual
+                    && ((UIContextual) contextual).getUiId() == uiId) {
+                final ContextualStorage storage = storageMap.remove(contextual);
+                destroyAllActive(storage);
             }
         }
         sessionData.uiDataMap.remove(uiId);

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AbstractVaadinContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AbstractVaadinContext.java
@@ -43,7 +43,7 @@ public abstract class AbstractVaadinContext extends AbstractContext {
 
     private final Object cleanupLock = new Object();
 
-    private static final int CLEANUP_DELAY = 5000;
+    public static final int CLEANUP_DELAY = 5000;
 
     private BeanManager beanManager;
     private Map<Long, SessionData> storageMap = new ConcurrentHashMap<Long, SessionData>();

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/VaadinContextualStorage.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/VaadinContextualStorage.java
@@ -2,29 +2,35 @@ package com.vaadin.cdi.internal;
 
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.apache.deltaspike.core.util.context.ContextualStorage;
 
 /**
- * Customized version of ContextualStorage to also handle beans that are not
- * PassivationCapable. Such beans are used as their own keys, which is not ideal
- * but should work in most single-JVM environments.
- * 
+ * Customized version of ContextualStorage to handle wrapper beans inherited
+ * from {@link UIContextual}. ( {@link UIBean}, and {@link ViewBean} )
+ *
+ * We need the bean to destroy the contextual instance properly.
+ * Since we cannot rely on passivation id to restore the beans,
+ * they used as their own keys.
+ *
+ * Except for wrapper beans, because UIContextual
+ * equals-hashCode designed to identify the context.
+ * We use delegate bean in this case.
+ *
  * @see ContextualStorage
  */
 public class VaadinContextualStorage extends ContextualStorage {
 
     public VaadinContextualStorage(BeanManager beanManager, boolean concurrent) {
-        super(beanManager, concurrent, true);
+        super(beanManager, concurrent, false);
     }
-    
+
     @Override
     public <T> Object getBeanKey(Contextual<T> bean) {
-        if(bean instanceof PassivationCapable) {
-            return super.getBeanKey(bean);    
+        if ((bean instanceof UIContextual)) {
+            return ((UIContextual) bean).delegate;
         } else {
-            return bean;
+            return super.getBeanKey(bean);
         }
     }
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/ViewScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/ViewScopedContext.java
@@ -144,15 +144,14 @@ public class ViewScopedContext extends AbstractVaadinContext {
         String activeViewName = uiData.getActiveView();
 
         Map<Contextual<?>, ContextualStorage> map = sessionData.getStorageMap();
-        for (Entry<Contextual<?>, ContextualStorage> entry : new ArrayList<Entry<Contextual<?>, ContextualStorage>>(
-                map.entrySet())) {
-            ViewContextual contextual = (ViewContextual) entry.getKey();
-            if (contextual.uiId == uiId
-                    && !contextual.viewIdentifier.equals(activeViewName)) {
-                getLogger().fine(
-                        "dropping " + contextual + " : " + entry.getValue());
-                map.remove(contextual);
-                destroy(contextual);
+        for (Contextual<?> key : new ArrayList<>(map.keySet())) {
+            if (key instanceof ViewContextual) {
+                ViewContextual contextual = (ViewContextual) key;
+                if (contextual.uiId == uiId
+                        && !contextual.viewIdentifier.equals(activeViewName)) {
+                    ContextualStorage storage = map.remove(contextual);
+                    destroyAllActive(storage);
+                }
             }
         }
     }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentTestSuiteIT.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentTestSuiteIT.java
@@ -18,7 +18,7 @@ import com.vaadin.cdi.shiro.ShiroTest;
         ScopedProducerTest.class, CrossInjectionTest.class, ShiroTest.class,
         InappropriateNestedServletInDeploymentTest.class,
         InappropriateCDIViewInDeploymentTest.class, NonPassivatingBeanTest.class,
-        UIDestroyTest.class})
+        UIDestroyTest.class, ViewDestroyTest.class})
 public class DeploymentTestSuiteIT {
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.uis.DestroyNormalUI;
 import com.vaadin.cdi.uis.DestroyUI;
 import com.vaadin.cdi.views.TestView;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -21,13 +22,18 @@ public class UIDestroyTest extends AbstractManagedCDIIntegrationTest {
     public static WebArchive deployment() {
         return ArchiveProvider.createWebArchive("uiDestroy",
                 DestroyUI.class,
+                DestroyNormalUI.class,
                 TestView.class);
+    }
+
+    protected Class<? extends DestroyUI> getUIClass() {
+        return DestroyUI.class;
     }
 
     @Test
     public void testViewChangeTriggersClosedUIDestroy() throws Exception {
         resetCounts();
-        uri = Conventions.deriveMappingForUI(DestroyUI.class);
+        uri = Conventions.deriveMappingForUI(getUIClass());
         openWindow(uri);
         uiId = findElement(DestroyUI.UIID_ID).getText();
         assertDestroyCount(0);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
@@ -49,6 +49,7 @@ public class UIDestroyTest extends AbstractManagedCDIIntegrationTest {
 
     private void assertDestroyCount(int count) throws IOException {
         assertThat(getCount(DestroyUI.DESTROY_COUNT + uiId), is(count));
+        assertThat(getCount(DestroyUI.UIScopedBean.DESTROY_COUNT + uiId), is(count));
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/UIDestroyTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.cdi;
 
+import com.vaadin.cdi.internal.AbstractVaadinContext;
 import com.vaadin.cdi.internal.Conventions;
 import com.vaadin.cdi.uis.DestroyNormalUI;
 import com.vaadin.cdi.uis.DestroyUI;
@@ -44,7 +45,7 @@ public class UIDestroyTest extends AbstractManagedCDIIntegrationTest {
         openWindow(uri);
         assertDestroyCount(0);
 
-        Thread.sleep(5000); //AbstractVaadinContext.CLEANUP_DELAY
+        Thread.sleep(AbstractVaadinContext.CLEANUP_DELAY + 1);
 
         //ViewChange event triggers a cleanup
         clickAndWait(DestroyUI.NAVIGATE_BTN_ID);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/UINormalDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/UINormalDestroyTest.java
@@ -1,0 +1,11 @@
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.uis.DestroyNormalUI;
+import com.vaadin.cdi.uis.DestroyUI;
+
+public class UINormalDestroyTest extends UIDestroyTest {
+    @Override
+    protected Class<? extends DestroyUI> getUIClass() {
+        return DestroyNormalUI.class;
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyNormalUITest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyNormalUITest.java
@@ -1,0 +1,11 @@
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.uis.DestroyViewNormalUI;
+import com.vaadin.cdi.uis.DestroyViewUI;
+
+public class ViewDestroyNormalUITest extends ViewDestroyTest {
+    @Override
+    protected Class<? extends DestroyViewUI> getUIClass() {
+        return DestroyViewNormalUI.class;
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
@@ -1,0 +1,62 @@
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.uis.DestroyViewUI;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ViewDestroyTest extends AbstractManagedCDIIntegrationTest {
+
+    private String viewUri;
+
+    @Deployment(name = "viewDestroy", testable = false)
+    public static WebArchive deployment() {
+        return ArchiveProvider.createWebArchive("viewDestroy", DestroyViewUI.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        resetCounts();
+        viewUri = Conventions.deriveMappingForUI(DestroyViewUI.class)+ "#!home";
+        openWindow(viewUri);
+        assertViewDestroyCounts(0);
+    }
+
+    @Test
+    @OperateOnDeployment("viewDestroy")
+    public void testViewDestroyOnUIDestroy() throws Exception {
+        clickAndWait(DestroyViewUI.CLOSE_BTN_ID);
+        openWindow(viewUri);
+        assertViewDestroyCounts(0);
+        clickAndWait(DestroyViewUI.CLOSE_BTN_ID);
+        Thread.sleep(5000); //AbstractVaadinContext.CLEANUP_DELAY
+
+        //open new UI. Navigating to home view on load triggers cleanup.
+        openWindow(viewUri);
+
+        assertViewDestroyCounts(2);
+    }
+
+    @Test
+    @OperateOnDeployment("viewDestroy")
+    public void testViewChangeDestroysViewScope() throws Exception {
+        //ViewChange event triggers a cleanup
+        clickAndWait(DestroyViewUI.NAVIGATE_BTN_ID);
+
+        assertViewDestroyCounts(1);
+    }
+
+    private void assertViewDestroyCounts(int count) throws IOException {
+        assertThat(getCount(DestroyViewUI.VIEW_DESTROY_COUNT_KEY), is(count));
+        assertThat(getCount(DestroyViewUI.VIEWBEAN_DESTROY_COUNT_KEY), is(count));
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
@@ -1,6 +1,8 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.internal.Conventions;
+import com.vaadin.cdi.uis.DestroyNormalUI;
+import com.vaadin.cdi.uis.DestroyViewNormalUI;
 import com.vaadin.cdi.uis.DestroyViewUI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -19,15 +21,21 @@ public class ViewDestroyTest extends AbstractManagedCDIIntegrationTest {
 
     @Deployment(name = "viewDestroy", testable = false)
     public static WebArchive deployment() {
-        return ArchiveProvider.createWebArchive("viewDestroy", DestroyViewUI.class);
+        return ArchiveProvider.createWebArchive("viewDestroy",
+                DestroyViewUI.class,
+                DestroyViewNormalUI.class);
     }
 
     @Before
     public void setUp() throws Exception {
         resetCounts();
-        viewUri = Conventions.deriveMappingForUI(DestroyViewUI.class)+ "#!home";
+        viewUri = Conventions.deriveMappingForUI(getUIClass()) + "#!home";
         openWindow(viewUri);
         assertViewDestroyCounts(0);
+    }
+
+    protected Class<? extends DestroyViewUI> getUIClass() {
+        return DestroyViewUI.class;
     }
 
     @Test

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/ViewDestroyTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.cdi;
 
+import com.vaadin.cdi.internal.AbstractVaadinContext;
 import com.vaadin.cdi.internal.Conventions;
 import com.vaadin.cdi.uis.DestroyNormalUI;
 import com.vaadin.cdi.uis.DestroyViewNormalUI;
@@ -45,7 +46,7 @@ public class ViewDestroyTest extends AbstractManagedCDIIntegrationTest {
         openWindow(viewUri);
         assertViewDestroyCounts(0);
         clickAndWait(DestroyViewUI.CLOSE_BTN_ID);
-        Thread.sleep(5000); //AbstractVaadinContext.CLEANUP_DELAY
+        Thread.sleep(AbstractVaadinContext.CLEANUP_DELAY + 1);
 
         //open new UI. Navigating to home view on load triggers cleanup.
         openWindow(viewUri);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyNormalUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyNormalUI.java
@@ -1,0 +1,9 @@
+package com.vaadin.cdi.uis;
+
+import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.NormalUIScoped;
+
+@CDIUI("normal")
+@NormalUIScoped
+public class DestroyNormalUI extends DestroyUI {
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyUI.java
@@ -13,11 +13,9 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import java.io.Serializable;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @CDIUI("")
 public class DestroyUI extends UI {
@@ -29,6 +27,9 @@ public class DestroyUI extends UI {
 
     @Inject
     CDIViewProvider viewProvider;
+
+    @Inject
+    UIScopedBean bean;
 
     @Inject
     Counter counter;
@@ -49,6 +50,7 @@ public class DestroyUI extends UI {
         label.setId(LABEL_ID);
         layout.addComponent(label);
 
+        bean.setUiId(getUIId());
         final Label uiId = new Label(String.valueOf(getUIId()));
         uiId.setId(UIID_ID);
         layout.addComponent(uiId);
@@ -80,6 +82,25 @@ public class DestroyUI extends UI {
         layout.addComponent(viewNavigateBtn);
 
         setContent(layout);
+    }
+
+    @UIScoped
+    public static class UIScopedBean implements Serializable {
+        public static final String DESTROY_COUNT = "uibeandestroycount";
+
+        int uiId;
+
+        @Inject
+        Counter counter;
+
+        @PreDestroy
+        public void destroy() {
+            counter.increment(DESTROY_COUNT + uiId);
+        }
+
+        public void setUiId(int uiId) {
+            this.uiId = uiId;
+        }
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyViewNormalUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyViewNormalUI.java
@@ -1,0 +1,9 @@
+package com.vaadin.cdi.uis;
+
+import com.vaadin.cdi.CDIUI;
+import com.vaadin.cdi.NormalUIScoped;
+
+@CDIUI("normal")
+@NormalUIScoped
+public class DestroyViewNormalUI extends DestroyViewUI {
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyViewUI.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/uis/DestroyViewUI.java
@@ -1,0 +1,115 @@
+package com.vaadin.cdi.uis;
+
+import com.vaadin.cdi.*;
+import com.vaadin.cdi.internal.Counter;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.io.Serializable;
+
+@CDIUI("viewDestroy")
+public class DestroyViewUI extends UI {
+    public static final String CLOSE_BTN_ID = "close";
+    public static final String LABEL_ID = "label";
+    public static final String VIEW_DESTROY_COUNT_KEY = "viewcount";
+    public static final String VIEWBEAN_DESTROY_COUNT_KEY = "viewbeancount";
+    public static final String NAVIGATE_BTN_ID = "navigate";
+
+    @Inject
+    CDIViewProvider viewProvider;
+    @Inject
+    Counter counter;
+
+    @Override
+    protected void init(VaadinRequest vaadinRequest) {
+        setSizeFull();
+
+        VerticalLayout layout = new VerticalLayout();
+        layout.setSizeFull();
+
+        final Label label = new Label("label");
+        label.setId(LABEL_ID);
+        layout.addComponent(label);
+
+        Button closeBtn = new Button("close UI");
+        closeBtn.setId(CLOSE_BTN_ID);
+        closeBtn.addClickListener(new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent event) {
+                close();
+            }
+        });
+        layout.addComponent(closeBtn);
+
+        final Navigator navigator = new Navigator(this, new ViewDisplay() {
+            @Override
+            public void showView(View view) {
+            }
+        });
+        navigator.addProvider(viewProvider);
+
+        Button viewNavigateBtn = new Button("navigate");
+        viewNavigateBtn.setId(NAVIGATE_BTN_ID);
+        viewNavigateBtn.addClickListener(new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent event) {
+                navigator.navigateTo("other");
+            }
+        });
+        layout.addComponent(viewNavigateBtn);
+
+        setContent(layout);
+    }
+
+    @CDIView(value = "home")
+    public static class HomeView implements View {
+        @Inject
+        ViewScopedBean viewScopedBean;
+
+        @Inject
+        Counter counter;
+
+        @PreDestroy
+        public void destroy() {
+            counter.increment(VIEW_DESTROY_COUNT_KEY);
+        }
+
+        @Override
+        public void enter(ViewChangeListener.ViewChangeEvent viewChangeEvent) {
+
+        }
+    }
+
+    @ViewScoped
+    public static class ViewScopedBean implements Serializable {
+        @Inject
+        Counter counter;
+
+        @PreDestroy
+        public void destroy() {
+            counter.increment(VIEWBEAN_DESTROY_COUNT_KEY);
+        }
+
+
+    }
+
+    @CDIView("other")
+    public static class OtherView implements View {
+
+        @Override
+        public void enter(ViewChangeListener.ViewChangeEvent event) {
+
+        }
+    }
+
+
+}

--- a/vaadin-cdi/src/test/resources/arquillian.xml
+++ b/vaadin-cdi/src/test/resources/arquillian.xml
@@ -7,4 +7,13 @@
         <property name="ensureCleanSession">true</property>
     </extension>
 
+    <container qualifier="wildfly">
+        <configuration>
+            <!-- Assertions must be disabled when @UIScoped is a @NormalScope
+                otherwise the core framework will fail assertions that compare
+                a direct reference to a proxy, such as in VaadinSession#removeUI
+                and ConnectorTracker#cleanConnectorMap (#14508) -->
+            <property name="enableAssertions">false</property>
+        </configuration>
+    </container>
 </arquillian>


### PR DESCRIPTION
To properly destroy contextual instances the Bean is needed.
A simple way to have a Bean to use as a key in ContextualStorage. 

Current implementation use the passivation id as a key for passivation capable beans. I can retain this behaviour with some additional effort, but I think more things have to revised for a working passivation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/195)
<!-- Reviewable:end -->
