### PR TITLE
Add wildcard mapping support for UIs

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
@@ -166,7 +166,9 @@ public class CDIUIProvider extends DefaultUIProvider implements Serializable {
                 if (beanClass.isAnnotationPresent(CDIUI.class)) {
                     String computedMapping = Conventions
                             .deriveMappingForUI(beanClass);
-                    if (mapping.equals(computedMapping)) {
+                    int wildcardIndex = computedMapping.lastIndexOf("*");
+                    if (mapping.equals(computedMapping) || (wildcardIndex >= 0
+                            && mapping.startsWith(computedMapping.substring(0, wildcardIndex)))) {
                         return bean;
                     }
                 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AnnotationUtil.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/AnnotationUtil.java
@@ -61,7 +61,7 @@ public class AnnotationUtil {
             }
 
             String path = Conventions.deriveMappingForUI(beanClass);
-            if (null != path && path.isEmpty()) {
+            if (null != path && (path.isEmpty() || path.equals("*"))) {
                 rootBeans.add(bean);
             }
         }


### PR DESCRIPTION
This add support for `@CDIUI("*")` and `@CDIUI("foo*")` to handle multiple paths with the same `UI`, e.g.

```java
@CDIUI("*")
public class MyUI extends UI {
  // ...
}
```
will serve `/`, `/foo`, `/foo/bar`.

This is needed when using the new FW 8 History API to push/pop states to the URI.

Closes #202.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/203)
<!-- Reviewable:end -->
