### PR TITLE
Revert "Tomcat DeltaManager session replication workaround"

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/server/VaadinCDIServletService.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/server/VaadinCDIServletService.java
@@ -74,13 +74,4 @@ public class VaadinCDIServletService extends VaadinServletService {
                 .getCanonicalName());
     }
 
-    @Override
-    protected void unlockSession(WrappedSession wrappedSession) {
-        if (wrappedSession != null) {
-            // workaround for https://github.com/vaadin/framework/issues/7535
-            // Tomcat DeltaManager need it
-            writeToHttpSession(wrappedSession, readFromHttpSession(wrappedSession));
-        }
-        super.unlockSession(wrappedSession);
-    }
 }


### PR DESCRIPTION
The workaround in this patch caused Payara and Glassfish servers to fail.

This reverts commit de2983e28de33623d673a01009deec99f64be8be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/218)
<!-- Reviewable:end -->
