### PR TITLE
Fix push state nav with non-empty context path and empty ui mapping

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CDIUIProvider.java
@@ -110,7 +110,7 @@ public class CDIUIProvider extends DefaultUIProvider {
         String uiMapping = parseUIMapping(request);
 
         Class<? extends UI> uiClass = null;
-        String pathInfo = "";
+        String pathInfo = request.getContextPath() + "/";
 
         if (isRoot(request)) {
             uiClass = rootUI();
@@ -120,7 +120,7 @@ public class CDIUIProvider extends DefaultUIProvider {
             if (uiBean != null) {
                 // Provide correct path info for UI for push state navigation
                 uiClass = uiBean.getBeanClass().asSubclass(UI.class);
-                pathInfo = removeWildcard(
+                pathInfo += removeWildcard(
                         Conventions.deriveMappingForUI(uiClass));
             }
         }


### PR DESCRIPTION
With a deployment path of `http://example.com/Context/`, and a UI mapped to "" or "/*", navigating to `page1` would result in `http://example.com/page1` rather than `http://example.com/Context/page1`.

Instead, include the context path in uiRootPath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/241)
<!-- Reviewable:end -->
