### PR TITLE
Deployment validation for normal scoped components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
                 <version>${vaadin.flow.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-html-components</artifactId>
+                <version>${vaadin.flow.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.webjars.bowergithub.polymer</groupId>
                 <artifactId>polymer</artifactId>
                 <version>2.6.0</version>

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/DeploymentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/DeploymentView.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.invaliddeployment;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("")
+public class DeploymentView extends Div {
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/NormalScopedLabel.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/NormalScopedLabel.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.invaliddeployment;
+
+import com.vaadin.cdi.annotation.NormalUIScoped;
+import com.vaadin.flow.component.html.Label;
+
+@NormalUIScoped
+public class NormalScopedLabel extends Label {
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest;
+
+import com.vaadin.cdi.itest.invaliddeployment.DeploymentView;
+import com.vaadin.cdi.itest.invaliddeployment.NormalScopedLabel;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.TestCase.fail;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class InvalidDeploymentTest {
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(name = "invalid-deployment", testable = false, managed = false)
+    public static WebArchive invalidDeployment() {
+        return ArchiveProvider.createWebArchive("invalid-deployment",
+                DeploymentView.class, NormalScopedLabel.class);
+    }
+
+    @Test(expected = Exception.class)
+    public void invalidDeploymentShouldBreakDeploy() {
+        deployer.deploy("invalid-deployment");
+        fail("An invalid deployment should break deploy!");
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
@@ -27,8 +27,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static junit.framework.TestCase.fail;
-
 @RunWith(Arquillian.class)
 @RunAsClient
 public class InvalidDeploymentTest {
@@ -45,7 +43,6 @@ public class InvalidDeploymentTest {
     @Test(expected = Exception.class)
     public void invalidDeploymentShouldBreakDeploy() {
         deployer.deploy("invalid-deployment");
-        fail("An invalid deployment should break deploy!");
     }
 
 }

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -55,6 +55,16 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.webjars.bowergithub.polymer</groupId>
+            <artifactId>polymer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import com.vaadin.flow.component.Component;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Dependent
+class DeploymentValidator {
+
+    @Inject
+    private BeanManager beanManager;
+
+    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+        infoSet.forEach(info -> validateBean(info).ifPresent(addDeploymentProblem));
+    }
+
+    private Optional<DeploymentProblem> validateBean(BeanInfo beanInfo) {
+        if (!beanInfo.isComponent()) {
+            return Optional.empty();
+        }
+        if (beanManager.isNormalScope(beanInfo.getScope())) {
+            Type baseType = beanInfo.getBaseType();
+            return Optional.of(new DeploymentProblem(String.format(
+                    "Normal scoped Vaadin components are not supported. " +
+                            "Should not belong to a normal scope: class '%s'",
+                    baseType.getTypeName()), baseType));
+        }
+        return Optional.empty();
+    }
+
+    static class BeanInfo {
+
+        private final Bean<?> bean;
+        private final Annotated annotated;
+
+        BeanInfo(Bean<?> bean, Annotated annotated) {
+            this.bean = bean;
+            this.annotated = annotated;
+        }
+
+        Type getBaseType() {
+            return annotated.getBaseType();
+        }
+
+        private Class<? extends Annotation> getScope() {
+            return bean.getScope();
+        }
+
+        private boolean isComponent() {
+            for (Type type : bean.getTypes()) {
+                if (type instanceof Class) {
+                    if (Component.class.isAssignableFrom((Class) type)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+    }
+
+    /**
+     * Represents a deployment problem to be passed to the container.
+     * Message and stacktrace will appear in server log.
+     * It is not thrown, or caught.
+     */
+    static class DeploymentProblem extends Throwable {
+
+        private final Type baseType;
+
+        private DeploymentProblem(String message, Type baseType) {
+            super(message);
+            this.baseType = baseType;
+        }
+
+        /**
+         * For testing purposes only.
+         * @return annotated base type of the invalid bean
+         */
+        Type getBaseType() {
+            return baseType;
+        }
+
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -41,6 +41,59 @@ import java.util.Locale;
 @RunWith(CdiTestRunner.class)
 public class CdiInstantiatorTest {
 
+    @Singleton
+    public static class SomeCdiBean {
+    }
+
+    public static class ParentBean {
+
+        @Inject
+        private BeanManager bm;
+
+        public BeanManager getBm() {
+            return bm;
+        }
+
+    }
+
+    @Vetoed
+    public static class NotACdiBean extends ParentBean {
+    }
+
+    public static class Ambiguous extends ParentBean {
+    }
+
+    @VaadinServiceEnabled
+    public static class I18NTestProvider implements I18NProvider {
+
+        @Override
+        public List<Locale> getProvidedLocales() {
+            return null;
+        }
+
+        @Override
+        public String getTranslation(String key, Locale locale,
+                                     Object... params) {
+            return null;
+        }
+
+    }
+
+    @RequestScoped
+    public static class ServiceInitObserver {
+
+        ServiceInitEvent event;
+
+        public void serviceInit(@Observes ServiceInitEvent event) {
+            this.event = event;
+        }
+
+        public ServiceInitEvent getEvent() {
+            return event;
+        }
+
+    }
+
     @Inject
     private BeanManager beanManager;
 
@@ -111,60 +164,6 @@ public class CdiInstantiatorTest {
         ParentBean instance = instantiator.getOrCreate(ParentBean.class);
         Assert.assertNotNull(instance);
         Assert.assertNotNull(instance.getBm());
-    }
-
-    @Singleton
-    public static class SomeCdiBean {
-    }
-
-    public static class ParentBean {
-
-        @Inject
-        private BeanManager bm;
-
-        public BeanManager getBm() {
-            return bm;
-        }
-
-    }
-
-
-    @Vetoed
-    public static class NotACdiBean extends ParentBean {
-    }
-
-    public static class Ambiguous extends ParentBean {
-    }
-
-    @VaadinServiceEnabled
-    public static class I18NTestProvider implements I18NProvider {
-
-        @Override
-        public List<Locale> getProvidedLocales() {
-            return null;
-        }
-
-        @Override
-        public String getTranslation(String key, Locale locale,
-                                     Object... params) {
-            return null;
-        }
-
-    }
-
-    @RequestScoped
-    public static class ServiceInitObserver {
-
-        ServiceInitEvent event;
-
-        public void serviceInit(@Observes ServiceInitEvent event) {
-            this.event = event;
-        }
-
-        public ServiceInitEvent getEvent() {
-            return event;
-        }
-
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+import com.vaadin.cdi.context.ServiceUnderTestContext;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Vetoed;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Locale;
+
+@RunWith(CdiTestRunner.class)
+public class CdiInstantiatorTest {
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Inject
+    @VaadinServiceEnabled
+    private CdiInstantiator instantiator;
+
+    @Inject
+    private SomeCdiBean singleton;
+
+    @Inject
+    private ServiceInitObserver serviceInitObserver;
+
+    private ServiceUnderTestContext serviceUnderTestContext;
+
+    @Before
+    public void setUp() {
+        serviceUnderTestContext = new ServiceUnderTestContext(beanManager);
+        serviceUnderTestContext.activate();
+        CdiVaadinServletService service = serviceUnderTestContext.getService();
+        Assert.assertTrue(instantiator.init(service));
+    }
+
+    @After
+    public void tearDown() {
+        serviceUnderTestContext.tearDownAll();
+    }
+
+    @Test
+    public void getI18NProvider_beanEnabled_instanceReturned() {
+        I18NProvider i18NProvider = instantiator.getI18NProvider();
+        Assert.assertNotNull(i18NProvider);
+        Assert.assertTrue((i18NProvider instanceof I18NTestProvider));
+    }
+
+    @Test
+    public void getServiceInitListeners_javaSPIListenerExists_containsJavaSPIListener() {
+        Assert.assertTrue(instantiator.getServiceInitListeners().anyMatch(
+                listener -> listener instanceof JavaSPIVaadinServiceInitListener));
+    }
+
+    @Test
+    public void getServiceInitListeners_eventFired_cdiObserverCalled() {
+        VaadinService service = Mockito.mock(VaadinService.class);
+        ServiceInitEvent event = new ServiceInitEvent(service);
+        instantiator.getServiceInitListeners()
+                .filter(listener -> listener.getClass().getPackage()
+                        .equals(CdiInstantiator.class.getPackage()))
+                .forEach(listener -> listener.serviceInit(event));
+        Assert.assertSame(event, serviceInitObserver.getEvent());
+    }
+
+    @Test
+    public void getOrCreate_beanSingleton_sameInstanceReturned() {
+        Assert.assertSame(singleton,
+                instantiator.getOrCreate(SomeCdiBean.class));
+    }
+
+    @Test
+    public void getOrCreate_beanUnsatisfied_instantiatedAndInjectionOccurred() {
+        NotACdiBean instance = instantiator.getOrCreate(NotACdiBean.class);
+        Assert.assertNotNull(instance);
+        Assert.assertNotNull(instance.getBm());
+    }
+
+    @Test
+    public void getOrCreate_beanAmbiguous_instantiatedAndInjectionOccurred() {
+        ParentBean instance = instantiator.getOrCreate(ParentBean.class);
+        Assert.assertNotNull(instance);
+        Assert.assertNotNull(instance.getBm());
+    }
+
+    @Singleton
+    public static class SomeCdiBean {
+    }
+
+    public static class ParentBean {
+
+        @Inject
+        private BeanManager bm;
+
+        public BeanManager getBm() {
+            return bm;
+        }
+
+    }
+
+
+    @Vetoed
+    public static class NotACdiBean extends ParentBean {
+    }
+
+    public static class Ambiguous extends ParentBean {
+    }
+
+    @VaadinServiceEnabled
+    public static class I18NTestProvider implements I18NProvider {
+
+        @Override
+        public List<Locale> getProvidedLocales() {
+            return null;
+        }
+
+        @Override
+        public String getTranslation(String key, Locale locale,
+                                     Object... params) {
+            return null;
+        }
+
+    }
+
+    @RequestScoped
+    public static class ServiceInitObserver {
+
+        ServiceInitEvent event;
+
+        public void serviceInit(@Observes ServiceInitEvent event) {
+            this.event = event;
+        }
+
+        public ServiceInitEvent getEvent() {
+            return event;
+        }
+
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -42,6 +42,22 @@ import static org.junit.Assert.assertTrue;
 @RunWith(CdiTestRunner.class)
 public class DeploymentValidatorTest {
 
+    @NormalUIScoped
+    public static class NormalScopedLabel extends Label {
+    }
+
+    @UIScoped
+    public static class PseudoScopedLabel extends Label {
+    }
+
+    @NormalUIScoped
+    public static class NormalScopedBean {
+    }
+
+    @Vetoed
+    public static class ProducedNormalScopedComponent extends Component {
+    }
+
     @Inject
     private TestDeploymentValidator validator;
 
@@ -85,27 +101,10 @@ public class DeploymentValidatorTest {
                 .collect(Collectors.toMap(DeploymentValidator.BeanInfo::getBaseType, Function.identity()));
     }
 
-
-    @NormalUIScoped
-    public static class NormalScopedLabel extends Label {
-    }
-
-    @UIScoped
-    public static class PseudoScopedLabel extends Label {
-    }
-
-    @NormalUIScoped
-    public static class NormalScopedBean {
-    }
-
     @Produces
     @NormalUIScoped
     private ProducedNormalScopedComponent getProducedComponent() {
         return new ProducedNormalScopedComponent();
-    }
-
-    @Vetoed
-    public static class ProducedNormalScopedComponent extends Component {
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.annotation.NormalUIScoped;
+import com.vaadin.cdi.annotation.UIScoped;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Label;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(CdiTestRunner.class)
+public class DeploymentValidatorTest {
+
+    @Inject
+    private TestDeploymentValidator validator;
+
+    @Inject
+    private TestDeploymentValidator.BeanInfoSetHolder beanInfoSetHolder;
+
+    @Test
+    public void validate_multipleNormalScopedProblems_collected() {
+        Set<DeploymentValidator.BeanInfo> infoSet = createBeanSet(
+                PseudoScopedLabel.class,
+                NormalScopedBean.class,
+                NormalScopedLabel.class,
+                ProducedNormalScopedComponent.class);
+
+        List<Throwable> problems = new ArrayList<>();
+        validator.validateForTest(infoSet, problems::add);
+
+        assertEquals(2, problems.size());
+
+        Set<Type> types = problems.stream()
+                .map(info -> ((DeploymentValidator.DeploymentProblem) info).getBaseType())
+                .collect(Collectors.toSet());
+
+        assertTrue(types.contains(NormalScopedLabel.class));
+        assertTrue(types.contains(ProducedNormalScopedComponent.class));
+    }
+
+    private Set<DeploymentValidator.BeanInfo> createBeanSet(Type... clazz) {
+        Map<Type, DeploymentValidator.BeanInfo> map = getBeanInfoSetAsMap();
+        return Arrays
+                .stream(clazz)
+                .map(map::get)
+                .collect(Collectors.toSet());
+    }
+
+    private Map<Type, DeploymentValidator.BeanInfo> getBeanInfoSetAsMap() {
+        return beanInfoSetHolder.getInfoSet().stream()
+                // Weld causes duplicate key because of exposing weird things as Object.
+                // Tests are not interested in it.
+                .filter(beanInfo -> !beanInfo.getBaseType().equals(Object.class))
+                .collect(Collectors.toMap(DeploymentValidator.BeanInfo::getBaseType, Function.identity()));
+    }
+
+
+    @NormalUIScoped
+    public static class NormalScopedLabel extends Label {
+    }
+
+    @UIScoped
+    public static class PseudoScopedLabel extends Label {
+    }
+
+    @NormalUIScoped
+    public static class NormalScopedBean {
+    }
+
+    @Produces
+    @NormalUIScoped
+    private ProducedNormalScopedComponent getProducedComponent() {
+        return new ProducedNormalScopedComponent();
+    }
+
+    @Vetoed
+    public static class ProducedNormalScopedComponent extends Component {
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/JavaSPIVaadinServiceInitListener.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/JavaSPIVaadinServiceInitListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+public class JavaSPIVaadinServiceInitListener
+        implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/PolymerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/PolymerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import com.vaadin.cdi.annotation.NormalUIScoped;
+import com.vaadin.cdi.annotation.UIScoped;
+import com.vaadin.cdi.context.UIUnderTestContext;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.component.polymertemplate.TemplateParser;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+@RunWith(CdiTestRunner.class)
+public class PolymerTest {
+
+    @Inject
+    private Provider<PseudoScopedLabel> pseudoScopedLabelProvider;
+    private TestTemplate template;
+    private UIUnderTestContext uiUnderTestContext;
+    private Instantiator instantiator;
+
+    @Before
+    public void setUp() throws Exception {
+        uiUnderTestContext = new UIUnderTestContext();
+        uiUnderTestContext.activate();
+        UI ui = uiUnderTestContext.getUi();
+        VaadinService service = ui.getSession().getService();
+        service.init();
+        instantiator = service.getInstantiator();
+        template = instantiator.getOrCreate(TestTemplate.class);
+    }
+
+    @After
+    public void tearDown() {
+        uiUnderTestContext.tearDownAll();
+    }
+
+    @Test
+    public void injectField_componentHasScope_scopedInstanceInjected() {
+        final PseudoScopedLabel label = pseudoScopedLabelProvider.get();
+        assertSame(label, template.pseudo);
+    }
+
+    @Test
+    public void injectField_componentHasScope_elementBindingSuccess() {
+        assertNotNull(template.pseudo.getElement().getNode().getParent());
+    }
+
+    /**
+     * Test to show element binding with a normal scoped component doesn't work.
+     * It is bound to a new element instead of the one in the template element tree.
+     * <p>
+     * Vaadin Component consumes binding info from thread local
+     * in the no-arg constructor. Proxies don't work.
+     */
+    @Test
+    public void injectField_componentNormalScoped_elementBindingFailure() {
+        assertNull(template.normal.getElement().getNode().getParent());
+    }
+
+    /**
+     * Test to show element binding with an already instantiated
+     * component doesn't work.
+     * <p>
+     * Because of the binding in Component constructor seen before.
+     */
+    @Test
+    public void injectField_instantiatedBeforeInjection_elementBindingFailure() {
+        // Instantiate a new template.
+        // Components are scoped, they won't be instantiated again.
+        template = instantiator.getOrCreate(TestTemplate.class);
+        assertNull(template.normal.getElement().getNode().getParent());
+    }
+
+    @UIScoped
+    @Tag("uiscoped-label")
+    public static class PseudoScopedLabel extends Label {
+    }
+
+    @NormalUIScoped
+    @Tag("normaluiscoped-label")
+    public static class NormalScopedLabel extends Label {
+    }
+
+    @Tag("test-template")
+    public static class TestTemplate extends PolymerTemplate<TemplateModel> {
+
+        @Id("pseudo")
+        private PseudoScopedLabel pseudo;
+
+        @Id("normal")
+        private NormalScopedLabel normal;
+
+        public TestTemplate() {
+            super(new TestTemplateParser(
+                    TestTemplate.class
+                            .getResourceAsStream("test-template.html")));
+        }
+
+    }
+
+    private static class TestTemplateParser implements TemplateParser {
+
+        private final InputStream content;
+
+        private TestTemplateParser(InputStream content) {
+            this.content = content;
+        }
+
+        @Override
+        public TemplateData getTemplateContent(Class<? extends PolymerTemplate<?>> clazz,
+                                               String tag,
+                                               VaadinService service) {
+            try {
+                Document document = Jsoup.parse(content,
+                        StandardCharsets.UTF_8.name(), "");
+                Element element = document.getElementsByTag("dom-module").get(0);
+                return new TemplateData("dummy", element);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Alternative
+@Dependent
+class TestDeploymentValidator extends DeploymentValidator {
+
+    @Inject
+    private BeanInfoSetHolder beanInfoSetHolder;
+
+    @Override
+    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+        // No-op.
+        // We need CDI to startup in Unit tests even with
+        // intentionally misconfigured beans.
+        beanInfoSetHolder.setInfoSet(infoSet);
+    }
+
+    void validateForTest(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+        super.validate(infoSet, addDeploymentProblem);
+    }
+
+    @ApplicationScoped
+    static class BeanInfoSetHolder {
+
+        private Set<BeanInfo> infoSet;
+
+        Set<BeanInfo> getInfoSet() {
+            return Collections.unmodifiableSet(infoSet);
+        }
+
+        void setInfoSet(Set<BeanInfo> infoSet) {
+            this.infoSet = infoSet;
+        }
+
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
@@ -28,21 +28,6 @@ import java.util.function.Consumer;
 @Dependent
 class TestDeploymentValidator extends DeploymentValidator {
 
-    @Inject
-    private BeanInfoSetHolder beanInfoSetHolder;
-
-    @Override
-    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
-        // No-op.
-        // We need CDI to startup in Unit tests even with
-        // intentionally misconfigured beans.
-        beanInfoSetHolder.setInfoSet(infoSet);
-    }
-
-    void validateForTest(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
-        super.validate(infoSet, addDeploymentProblem);
-    }
-
     @ApplicationScoped
     static class BeanInfoSetHolder {
 
@@ -56,6 +41,21 @@ class TestDeploymentValidator extends DeploymentValidator {
             this.infoSet = infoSet;
         }
 
+    }
+
+    @Inject
+    private BeanInfoSetHolder beanInfoSetHolder;
+
+    @Override
+    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+        // No-op.
+        // We need CDI to startup in Unit tests even with
+        // intentionally misconfigured beans.
+        beanInfoSetHolder.setInfoSet(infoSet);
+    }
+
+    void validateForTest(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+        super.validate(infoSet, addDeploymentProblem);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
@@ -69,4 +69,9 @@ public class UIUnderTestContext implements UnderTestContext {
     public void destroy() {
         ComponentUtil.onComponentDetach(ui);
     }
+
+    public UI getUi() {
+        return ui;
+    }
+
 }

--- a/vaadin-cdi/src/test/resources/META-INF/beans.xml
+++ b/vaadin-cdi/src/test/resources/META-INF/beans.xml
@@ -5,4 +5,8 @@
         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
                       http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
         bean-discovery-mode="all">
+
+    <alternatives>
+        <class>com.vaadin.cdi.TestDeploymentValidator</class>
+    </alternatives>
 </beans>

--- a/vaadin-cdi/src/test/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/vaadin-cdi/src/test/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.vaadin.cdi.JavaSPIVaadinServiceInitListener

--- a/vaadin-cdi/src/test/resources/com/vaadin/cdi/test-template.html
+++ b/vaadin-cdi/src/test/resources/com/vaadin/cdi/test-template.html
@@ -1,0 +1,8 @@
+<dom-module id="test-template">
+    <template>
+        <div>
+            <uiscoped-label id="pseudo"/>
+            <normaluiscoped-label id="normal"/>
+        </div>
+    </template>
+</dom-module>

--- a/vaadin-cdi/src/test/resources/com/vaadin/cdi/test-template.html
+++ b/vaadin-cdi/src/test/resources/com/vaadin/cdi/test-template.html
@@ -1,8 +1,0 @@
-<dom-module id="test-template">
-    <template>
-        <div>
-            <uiscoped-label id="pseudo"/>
-            <normaluiscoped-label id="normal"/>
-        </div>
-    </template>
-</dom-module>


### PR DESCRIPTION
Any normal scoped CDI bean with a component type breaks deployment.
Contains unit test for polymer template field injection, and a case when a normal scoped component does not work.
Test for CdiInstantiator also included. Not affected, it is just missed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/253)
<!-- Reviewable:end -->
