### PR TITLE
Introduce @RouteScoped context

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+public class AbstractCountedBean implements CountedPerUI {
+
+    private String data = "";
+
+    @PostConstruct
+    private void construct() {
+        countConstruct();
+    }
+
+    @PreDestroy
+    private void destroy() {
+        countDestroy();
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedView.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.flow.component.html.Div;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+public abstract class AbstractCountedView extends Div implements CountedPerUI {
+
+    @PostConstruct
+    private void construct() {
+        countConstruct();
+    }
+
+    @PreDestroy
+    private void destroy() {
+        countDestroy();
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ApartBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ApartBean.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+
+import com.vaadin.cdi.annotation.NormalRouteScoped;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+
+@NormalRouteScoped
+@RouteScopeOwner(DetailApartView.class)
+public class ApartBean extends AbstractCountedBean {
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AssignedBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AssignedBean.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+
+import com.vaadin.cdi.annotation.NormalRouteScoped;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+
+@NormalRouteScoped
+@RouteScopeOwner(MasterView.class)
+public class AssignedBean extends AbstractCountedBean {
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CountedPerUI.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CountedPerUI.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.itest.Counter;
+import com.vaadin.flow.component.UI;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+public interface CountedPerUI {
+
+    default int getUiId() {
+        return UI.getCurrent().getUIId();
+    }
+
+    default Counter getCounter() {
+        return BeanProvider.getContextualReference(Counter.class);
+    }
+
+    default void countConstruct() {
+        getCounter().increment(getClass().getSimpleName() + "C" + getUiId());
+    }
+
+    default void countDestroy() {
+        getCounter().increment(getClass().getSimpleName() + "D" + getUiId());
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailApartView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailApartView.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@RouteScoped
+@Route(value = "apart", layout = MasterView.class)
+public class DetailApartView extends AbstractCountedView implements AfterNavigationObserver {
+
+    public static final String MASTER = "master";
+    public static final String BEAN_LABEL = "BEAN_LABEL";
+
+    @Inject
+    @RouteScopeOwner(DetailApartView.class)
+    private ApartBean apartBean;
+    private Label apartLabel;
+
+    @PostConstruct
+    private void init() {
+        apartLabel = new Label();
+        apartLabel.setId(BEAN_LABEL);
+        apartBean.setData("APART");
+        add(
+                apartLabel,
+                new Div(new RouterLink(MASTER, MasterView.class))
+        );
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        apartLabel.setText(apartBean.getData());
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailAssignedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailAssignedView.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@RouteScoped
+@RouteScopeOwner(MasterView.class)
+@Route(value = "assigned", layout = MasterView.class)
+public class DetailAssignedView extends AbstractCountedView implements AfterNavigationObserver {
+
+    public static final String MASTER = "master";
+    public static final String BEAN_LABEL = "BEAN_LABEL";
+
+    @Inject
+    @RouteScopeOwner(MasterView.class)
+    private AssignedBean assignedBean;
+    private Label assignedLabel;
+
+    @PostConstruct
+    private void init() {
+        assignedLabel = new Label();
+        assignedLabel.setId(BEAN_LABEL);
+        assignedBean.setData("ASSIGNED");
+        add(
+                assignedLabel,
+                new Div(new RouterLink(MASTER, MasterView.class))
+        );
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        assignedLabel.setText(assignedBean.getData());
+    }
+
+}
+

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.ParentLayout;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RouteScoped
+@RouteScopeOwner(ErrorParentView.class)
+@ParentLayout(ErrorParentView.class)
+public class ErrorHandlerView extends AbstractCountedView
+        implements HasErrorParameter<NullPointerException> {
+
+    public static final String PARENT = "parent";
+
+    @Override
+    public int setErrorParameter(BeforeEnterEvent event,
+                                 ErrorParameter<NullPointerException> parameter) {
+        add(
+                new RouterLink(PARENT, ErrorParentView.class)
+        );
+        return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+
+@RouteScoped
+@Route("error-layout")
+public class ErrorParentView extends AbstractCountedView
+        implements RouterLayout {
+
+    public static final String ROOT = "root";
+
+    @PostConstruct
+    private void init() {
+        add(new RouterLink(ROOT, RootView.class));
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
@@ -27,7 +27,9 @@ public class ErrorView extends AbstractCountedView implements BeforeEnterObserve
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        if (true) throw new NullPointerException();
+        if (true) {
+            throw new NullPointerException();
+        }
     }
 
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@RouteScoped
+@Route("error")
+public class ErrorView extends AbstractCountedView implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        if (true) throw new NullPointerException();
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventView.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+@Route("event")
+@RouteScoped
+public class EventView extends Div {
+
+    public static final String FIRE = "FIRE";
+    public static final String OBSERVER_LABEL = "OBSERVER_LABEL";
+
+    @RouteScoped
+    @RouteScopeOwner(EventView.class)
+    public static class ObserverLabel extends Label {
+        private void onPrintEvent(@Observes PrintEvent printEvent) {
+            setText(printEvent.getMessage());
+        }
+    }
+
+    public static class PrintEvent {
+        private final String message;
+
+        public PrintEvent(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    @Inject
+    @RouteScopeOwner(EventView.class)
+    private Label label;
+    @Inject
+    private Event<PrintEvent> printEventTrigger;
+
+    @PostConstruct
+    private void init() {
+        label.setId(OBSERVER_LABEL);
+        NativeButton fireBtn = new NativeButton("fire event", clickEvent
+                -> printEventTrigger.fire(new PrintEvent("HELLO")));
+        fireBtn.setId(FIRE);
+
+        add(fireBtn, label);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RoutePrefix;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@RouteScoped
+@Route("")
+@RoutePrefix("master")
+public class MasterView extends AbstractCountedView
+        implements RouterLayout, AfterNavigationObserver {
+
+    public static final String ASSIGNED = "assigned";
+    public static final String ASSIGNED_BEAN_LABEL = "ASSIGNED";
+    public static final String APART = "apart";
+    public static final String APART_BEAN_LABEL = "APART";
+
+    @Inject
+    @RouteScopeOwner(MasterView.class)
+    private AssignedBean assignedBean;
+    @Inject
+    @RouteScopeOwner(DetailApartView.class)
+    private ApartBean apartBean;
+    private Label assignedLabel;
+    private Label apartLabel;
+
+    @PostConstruct
+    private void init() {
+        assignedLabel = new Label();
+        assignedLabel.setId(ASSIGNED_BEAN_LABEL);
+        apartLabel = new Label();
+        apartLabel.setId(APART_BEAN_LABEL);
+        add(
+                new Label("MASTER"),
+                new Div(assignedLabel),
+                new Div(apartLabel),
+                new Div(new RouterLink(ASSIGNED, DetailAssignedView.class)),
+                new Div(new RouterLink(APART, DetailApartView.class))
+        );
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        assignedLabel.setText(assignedBean.getData());
+        apartLabel.setText(apartBean.getData());
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PostponeView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PostponeView.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.BeforeLeaveEvent;
+import com.vaadin.flow.router.BeforeLeaveObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+
+@Route("postpone")
+@RouteScoped
+public class PostponeView extends AbstractCountedView implements BeforeLeaveObserver {
+
+    public static final String NAVIGATE = "NAVIGATE";
+    public static final String POSTPONED_ROOT = "postpone";
+
+    private BeforeLeaveEvent.ContinueNavigationAction navigationAction;
+
+    @PostConstruct
+    private void init() {
+        NativeButton navBtn = new NativeButton("navigate", clickEvent
+                -> navigationAction.proceed());
+        navBtn.setId(NAVIGATE);
+
+        add(
+                new Div(new RouterLink(POSTPONED_ROOT, RootView.class)),
+                new Div(navBtn)
+        );
+    }
+
+    @Override
+    public void beforeLeave(BeforeLeaveEvent beforeLeaveEvent) {
+        navigationAction = beforeLeaveEvent.postpone();
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RerouteView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RerouteView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("reroute")
+@RouteScoped
+public class RerouteView extends AbstractCountedView implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        event.rerouteTo(RootView.class);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+import javax.annotation.PostConstruct;
+
+@Route("")
+@RouteScoped
+public class RootView extends AbstractCountedView {
+
+    public static final String MASTER = "master";
+    public static final String REROUTE = "reroute";
+    public static final String POSTPONE = "postpone";
+    public static final String UIID = "UIID";
+    public static final String EVENT = "event";
+    public static final String ERROR = "ERROR";
+
+    @PostConstruct
+    private void init() {
+        Label uiIdLabel = new Label(UI.getCurrent().getUIId() + "");
+        uiIdLabel.setId(UIID);
+        add(
+                new Div(uiIdLabel),
+                new Div(new Label("ROOT")),
+                new Div(new RouterLink(MASTER, MasterView.class)),
+                new Div(new RouterLink(REROUTE, RerouteView.class)),
+                new Div(new RouterLink(POSTPONE, PostponeView.class)),
+                new Div(new RouterLink(EVENT, EventView.class)),
+                new Div(new RouterLink(ERROR, ErrorView.class))
+        );
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest;
+
+import com.vaadin.cdi.itest.routecontext.ApartBean;
+import com.vaadin.cdi.itest.routecontext.AssignedBean;
+import com.vaadin.cdi.itest.routecontext.DetailApartView;
+import com.vaadin.cdi.itest.routecontext.DetailAssignedView;
+import com.vaadin.cdi.itest.routecontext.ErrorHandlerView;
+import com.vaadin.cdi.itest.routecontext.ErrorParentView;
+import com.vaadin.cdi.itest.routecontext.ErrorView;
+import com.vaadin.cdi.itest.routecontext.EventView;
+import com.vaadin.cdi.itest.routecontext.MasterView;
+import com.vaadin.cdi.itest.routecontext.PostponeView;
+import com.vaadin.cdi.itest.routecontext.RerouteView;
+import com.vaadin.cdi.itest.routecontext.RootView;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class RouteContextTest extends AbstractCdiTest {
+
+    private String uiId;
+
+    @Deployment(testable = false)
+    public static WebArchive deployment() {
+        return ArchiveProvider.createWebArchive("route-context", webArchive ->
+                webArchive.addPackage(MasterView.class.getPackage()));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        resetCounts();
+        open("");
+        uiId = getText(RootView.UIID);
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 0);
+        assertConstructed(RerouteView.class, 0);
+        assertConstructed(MasterView.class, 0);
+        assertConstructed(AssignedBean.class, 0);
+        assertConstructed(ApartBean.class, 0);
+        assertConstructed(DetailApartView.class, 0);
+        assertConstructed(DetailAssignedView.class, 0);
+        assertConstructed(ErrorParentView.class, 0);
+        assertConstructed(ErrorHandlerView.class, 0);
+    }
+
+    @Test
+    public void navigateFromRootToMasterReleasesRootInjectsEmptyBeans()
+            throws IOException {
+        follow(RootView.MASTER);
+        assertTextEquals("", MasterView.ASSIGNED_BEAN_LABEL);
+        assertTextEquals("", MasterView.APART_BEAN_LABEL);
+
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 1);
+        assertConstructed(MasterView.class, 1);
+        assertDestroyed(MasterView.class, 0);
+        assertConstructed(AssignedBean.class, 1);
+        assertDestroyed(AssignedBean.class, 0);
+        assertConstructed(ApartBean.class, 1);
+        assertDestroyed(ApartBean.class, 0);
+        assertConstructed(DetailApartView.class, 0);
+        assertConstructed(DetailAssignedView.class, 0);
+    }
+
+    @Test
+    public void navigationFromAssignedToMasterHoldsGroup() throws IOException {
+        follow(RootView.MASTER);
+        follow(MasterView.ASSIGNED);
+        assertTextEquals("ASSIGNED", DetailAssignedView.BEAN_LABEL);
+        assertTextEquals("", MasterView.APART_BEAN_LABEL);
+
+        follow(DetailAssignedView.MASTER);
+        assertConstructed(MasterView.class, 1);
+        assertDestroyed(MasterView.class, 0);
+        assertConstructed(DetailAssignedView.class, 1);
+        assertDestroyed(DetailAssignedView.class, 0);
+        assertConstructed(DetailApartView.class, 0);
+
+        assertTextEquals("ASSIGNED", MasterView.ASSIGNED_BEAN_LABEL);
+        assertTextEquals("", MasterView.APART_BEAN_LABEL);
+    }
+
+    @Test
+    public void navigationFromApartToMasterReleasesGroup() throws IOException {
+        follow(RootView.MASTER);
+        follow(MasterView.APART);
+        assertTextEquals("", MasterView.ASSIGNED_BEAN_LABEL);
+        assertTextEquals("APART", DetailApartView.BEAN_LABEL);
+
+        follow(DetailApartView.MASTER);
+        assertConstructed(MasterView.class, 1);
+        assertDestroyed(MasterView.class, 0);
+        assertConstructed(DetailAssignedView.class, 0);
+        assertDestroyed(DetailAssignedView.class, 0);
+        assertConstructed(DetailApartView.class, 1);
+        assertDestroyed(DetailApartView.class, 1);
+
+        assertTextEquals("", MasterView.ASSIGNED_BEAN_LABEL);
+        assertTextEquals("", MasterView.APART_BEAN_LABEL);
+    }
+
+    @Test
+    public void rerouteReleasesSource() throws IOException {
+        follow(RootView.REROUTE);
+        assertConstructed(RerouteView.class, 1);
+        assertDestroyed(RerouteView.class, 1);
+
+        assertRootViewIsDisplayed();
+    }
+
+    @Test
+    public void postponedNavigationDoesNotCreateTarget() throws IOException {
+        follow(RootView.POSTPONE);
+        assertConstructed(RootView.class, 1);
+
+        follow(PostponeView.POSTPONED_ROOT);
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 1);
+
+        click(PostponeView.NAVIGATE);
+        assertConstructed(RootView.class, 2);
+        assertDestroyed(RootView.class, 1);
+        assertRootViewIsDisplayed();
+    }
+
+    @Test
+    public void eventObserved() {
+        follow(RootView.EVENT);
+        assertTextEquals("", EventView.OBSERVER_LABEL);
+
+        click(EventView.FIRE);
+        assertTextEquals("HELLO", EventView.OBSERVER_LABEL);
+    }
+
+    @Test
+    public void errorHandlerIsScoped() throws IOException {
+        follow(RootView.ERROR);
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 1);
+        assertConstructed(ErrorView.class, 1);
+        assertDestroyed(ErrorView.class, 1);
+        assertConstructed(ErrorParentView.class, 1);
+        assertDestroyed(ErrorParentView.class, 0);
+        assertConstructed(ErrorHandlerView.class, 1);
+        assertDestroyed(ErrorHandlerView.class, 0);
+
+        follow(ErrorHandlerView.PARENT);
+        assertConstructed(ErrorParentView.class, 1);
+        assertDestroyed(ErrorParentView.class, 0);
+        assertConstructed(ErrorHandlerView.class, 1);
+        assertDestroyed(ErrorHandlerView.class, 0);
+
+        follow(ErrorParentView.ROOT);
+        assertConstructed(RootView.class, 2);
+        assertDestroyed(RootView.class, 1);
+        assertConstructed(ErrorParentView.class, 1);
+        assertDestroyed(ErrorParentView.class, 1);
+        assertConstructed(ErrorHandlerView.class, 1);
+        assertDestroyed(ErrorHandlerView.class, 1);
+
+        assertRootViewIsDisplayed();
+    }
+
+    private void assertRootViewIsDisplayed() {
+        assertTextEquals(uiId, RootView.UIID);
+    }
+
+    private void assertConstructed(Class beanClass, int count) throws IOException {
+        Assert.assertEquals(count, getCount(beanClass.getSimpleName() + "C" + uiId));
+    }
+
+    private void assertDestroyed(Class beanClass, int count) throws IOException {
+        Assert.assertEquals(count, getCount(beanClass.getSimpleName() + "D" + uiId));
+    }
+
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
@@ -17,8 +17,10 @@
 package com.vaadin.cdi;
 
 import com.vaadin.cdi.DeploymentValidator.BeanInfo;
+import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.NormalUIScoped;
 import com.vaadin.cdi.context.ContextWrapper;
+import com.vaadin.cdi.context.RouteScopedContext;
 import com.vaadin.cdi.context.UIScopedContext;
 import com.vaadin.cdi.context.VaadinServiceScopedContext;
 import com.vaadin.cdi.context.VaadinSessionScopedContext;
@@ -45,6 +47,7 @@ public class VaadinExtension implements Extension {
 
     private VaadinServiceScopedContext serviceScopedContext;
     private UIScopedContext uiScopedContext;
+    private RouteScopedContext routeScopedContext;
     private Set<BeanInfo> beanInfoSet = new HashSet<>();
 
     private void storeBeanValidationInfo(@Observes ProcessBean processBean) {
@@ -56,16 +59,19 @@ public class VaadinExtension implements Extension {
                              BeanManager beanManager) {
         serviceScopedContext = new VaadinServiceScopedContext(beanManager);
         uiScopedContext = new UIScopedContext(beanManager);
+        routeScopedContext = new RouteScopedContext(beanManager);
         addContext(afterBeanDiscovery, serviceScopedContext, null);
         addContext(afterBeanDiscovery,
                 new VaadinSessionScopedContext(beanManager), null);
         addContext(afterBeanDiscovery, uiScopedContext, NormalUIScoped.class);
+        addContext(afterBeanDiscovery, routeScopedContext, NormalRouteScoped.class);
     }
 
     private void initializeContexts(@Observes AfterDeploymentValidation adv,
                                     BeanManager beanManager) {
         serviceScopedContext.init(beanManager);
         uiScopedContext.init(beanManager);
+        routeScopedContext.init(beanManager, uiScopedContext::isActive);
     }
 
     private void validateDeployment(@Observes AfterDeploymentValidation adv,

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/NormalRouteScoped.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/NormalRouteScoped.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.annotation;
+
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+
+import javax.enterprise.context.NormalScope;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The lifecycle of a NormalRouteScoped bean is controlled by route navigation.
+ * <p>
+ * Every NormalRouteScoped bean belongs to one router component owner.
+ * It can be a {@link Route @Route}, or a {@link RouterLayout},
+ * or a {@link HasErrorParameter HasErrorParameter}.
+ * Beans are qualified by {@link RouteScopeOwner @RouteScopeOwner}
+ * to link with their owner.
+ * <p>
+ * Until owner remains active, all beans owned by it remain in the scope.
+ * <p>
+ * You cannot use this scope with Vaadin Components. Proxy Components do not
+ * work correctly within the Vaadin framework, so as a precaution the Vaadin CDI
+ * plugin will not deploy if any such beans are discovered.
+ * <p>
+ * The sister annotation to this is the {@link RouteScoped}. Both annotations
+ * reference the same underlying scope, so it is possible to get both a proxy
+ * and a direct reference to the same object by using different annotations.
+ */
+@NormalScope
+@Inherited
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD,
+        ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NormalRouteScoped {
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScopeOwner.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScopeOwner.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.annotation;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Link a {@link RouteScoped @RouteScoped},
+ * or {@link NormalRouteScoped @NormalRouteScoped} bean to its owner.
+ * <p>
+ * Owner is a router component.
+ * A {@link Route @Route}, or a {@link RouterLayout}, or a {@link HasErrorParameter}.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface RouteScopeOwner {
+    /**
+     * Owner class of the qualified {@link RouteScoped @RouteScoped},
+     * or {@link NormalRouteScoped @NormalRouteScoped} bean.
+     * <p>
+     * A {@link Route @Route}, or a {@link RouterLayout}, or a {@link HasErrorParameter}
+     *
+     * @return owner class
+     */
+    Class<? extends HasElement> value();
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScoped.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScoped.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.annotation;
+
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+
+import javax.inject.Scope;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The lifecycle of a RouteScoped component is controlled by route navigation.
+ * <p>
+ * Every RouteScoped bean belongs to one router component owner.
+ * It can be a {@link Route @Route}, or a {@link RouterLayout},
+ * or a {@link HasErrorParameter HasErrorParameter}.
+ * Beans are qualified by {@link RouteScopeOwner @RouteScopeOwner}
+ * to link with their owner.
+ * <p>
+ * Until owner remains active, all beans owned by it remain in the scope.
+ * <p>
+ * When a RouteScoped bean is a router component,
+ * an owner can be any ancestor {@link RouterLayout}, or the bean itself.
+ * Omitting the RouteScopeOwner annotation means owner is the bean itself.
+ * <p>
+ * Injection with this annotation will create a direct reference to the object
+ * rather than a proxy.
+ * <p>
+ * There are some limitations when not using proxies. Circular referencing (that
+ * is, injecting A to B and B to A) will not work.
+ * Injecting into a larger scope will bind the instance
+ * from the currently active smaller scope, and will ignore smaller scope change.
+ * For example after being injected into session scope it will point to the same
+ * RouteScoped bean instance ( even it is destroyed ) regardless of UI,
+ * or any navigation change.
+ * <p>
+ * The sister annotation to this is the {@link NormalRouteScoped}. Both annotations
+ * reference the same underlying scope, so it is possible to get both a proxy
+ * and a direct reference to the same object by using different annotations.
+ */
+@Scope
+@Inherited
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD,
+        ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RouteScoped {
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -24,8 +24,10 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -82,6 +84,10 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
         if (storage != null) {
             AbstractContext.destroyAllActive(storage);
         }
+    }
+
+    protected Set<K> getKeySet() {
+        return Collections.unmodifiableSet(storageMap.keySet());
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.context;
+
+import com.vaadin.cdi.annotation.NormalUIScoped;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+import org.apache.deltaspike.core.util.context.AbstractContext;
+import org.apache.deltaspike.core.util.context.ContextualStorage;
+
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.PassivationCapable;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static javax.enterprise.event.Reception.IF_EXISTS;
+
+/**
+ * Context for {@link RouteScoped @RouteScoped} beans.
+ */
+public class RouteScopedContext extends AbstractContext {
+
+    @NormalUIScoped
+    public static class ContextualStorageManager
+            extends AbstractContextualStorageManager<Class> {
+
+        public ContextualStorageManager() {
+            // Session lock checked in VaadinSessionScopedContext while
+            // getting the session attribute.
+            super(false);
+        }
+
+        private void onAfterNavigation(@Observes(notifyObserver = IF_EXISTS)
+                                               AfterNavigationEvent event) {
+            Set<Class> activeChain = event.getActiveChain().stream()
+                    .map(Object::getClass)
+                    .collect(Collectors.toSet());
+
+            Set<Class> missingFromChain = getKeySet().stream()
+                    .filter(routeCompClass -> !activeChain.contains(routeCompClass))
+                    .collect(Collectors.toSet());
+
+            missingFromChain.forEach(this::destroy);
+        }
+
+    }
+
+    private ContextualStorageManager contextManager;
+    private Supplier<Boolean> isUIContextActive;
+    private BeanManager beanManager;
+
+    public RouteScopedContext(BeanManager beanManager) {
+        super(beanManager);
+    }
+
+    public void init(BeanManager beanManager,
+                     Supplier<Boolean> isUIContextActive) {
+        contextManager = BeanProvider
+                .getContextualReference(beanManager, ContextualStorageManager.class, false);
+        this.beanManager = beanManager;
+        this.isUIContextActive = isUIContextActive;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return RouteScoped.class;
+    }
+
+    @Override
+    public boolean isActive() {
+        return isUIContextActive.get();
+    }
+
+    @Override
+    protected ContextualStorage getContextualStorage(Contextual<?> contextual,
+                                                     boolean createIfNotExist) {
+        Class key = convertToKey(contextual);
+        return contextManager.getContextualStorage(key, createIfNotExist);
+    }
+
+    private Class convertToKey(Contextual<?> contextual) {
+        if (!(contextual instanceof Bean)) {
+            if (contextual instanceof PassivationCapable) {
+                final String id = ((PassivationCapable) contextual).getId();
+                contextual = beanManager.getPassivationCapableBean(id);
+            } else {
+                throw new IllegalArgumentException(
+                        contextual.getClass().getName()
+                                + " is not of type " + Bean.class.getName());
+            }
+        }
+        final Bean<?> bean = (Bean<?>) contextual;
+        return bean.getQualifiers()
+                .stream()
+                .filter(annotation -> annotation instanceof RouteScopeOwner)
+                .map(annotation -> (Class) (((RouteScopeOwner) annotation).value()))
+                .findFirst()
+                .orElse(bean.getBeanClass());
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextNormalTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextNormalTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.context;
+
+import com.vaadin.cdi.annotation.NormalRouteScoped;
+import com.vaadin.flow.router.Route;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(CdiTestRunner.class)
+public class RouteContextNormalTest
+        extends AbstractContextTest<RouteContextNormalTest.RouteScopedTestBean> {
+
+    @NormalRouteScoped
+    @Route("")
+    public static class RouteScopedTestBean extends TestBean {
+    }
+
+    @Override
+    protected Class<RouteScopedTestBean> getBeanType() {
+        return RouteScopedTestBean.class;
+    }
+
+    @Override
+    protected UnderTestContext newContextUnderTest() {
+        // Intentionally UI Under Test Context. Nothing else needed.
+        return new UIUnderTestContext();
+    }
+
+    @Override
+    protected boolean isNormalScoped() {
+        return true;
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextPseudoTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextPseudoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.context;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.router.Route;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(CdiTestRunner.class)
+public class RouteContextPseudoTest
+        extends AbstractContextTest<RouteContextPseudoTest.RouteScopedTestBean> {
+
+    @RouteScoped
+    @Route("")
+    public static class RouteScopedTestBean extends TestBean {
+    }
+
+    @Override
+    protected Class<RouteScopedTestBean> getBeanType() {
+        return RouteScopedTestBean.class;
+    }
+
+    @Override
+    protected UnderTestContext newContextUnderTest() {
+        // Intentionally UI Under Test Context. Nothing else needed.
+        return new UIUnderTestContext();
+    }
+
+    @Override
+    protected boolean isNormalScoped() {
+        return false;
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.context;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.Route;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(CdiTestRunner.class)
+public class RouteContextualStorageManagerTest {
+
+    private static final String STATE = "hello";
+
+    private abstract static class HasElementTestBean extends TestBean implements HasElement {
+        @Override
+        public Element getElement() {
+            return null;
+        }
+    }
+
+    @RouteScoped
+    @Route("group1")
+    public static class Group1 extends HasElementTestBean  {
+    }
+
+    @RouteScoped
+    @RouteScopeOwner(Group1.class)
+    public static class MemberOfGroup1 extends HasElementTestBean {
+    }
+
+    @RouteScoped
+    @Route("group2")
+    public static class Group2 extends HasElementTestBean {
+    }
+
+    private UIUnderTestContext uiUnderTestContext;
+
+    @Inject
+    private Provider<Group1> group1;
+
+    @Inject
+    @RouteScopeOwner(Group1.class)
+    private Provider<MemberOfGroup1> memberOfGroup1;
+
+    @Inject
+    private Provider<Group2> group2;
+
+    @Inject
+    private Event<AfterNavigationEvent> afterNavigationTrigger;
+
+    private List<HasElement> chain;
+    private AfterNavigationEvent event;
+
+    @Before
+    public void setUp() {
+        uiUnderTestContext = new UIUnderTestContext();
+        uiUnderTestContext.activate();
+
+        group1.get().setState(STATE);
+        group2.get().setState(STATE);
+        memberOfGroup1.get().setState(STATE);
+
+        assertEquals(STATE, group1.get().getState());
+        assertEquals(STATE, memberOfGroup1.get().getState());
+        assertEquals(STATE, group2.get().getState());
+
+        chain = new ArrayList<>();
+        event = Mockito.mock(AfterNavigationEvent.class);
+        Mockito.when(event.getActiveChain()).thenReturn(chain);
+    }
+
+    @After
+    public void tearDown() {
+        uiUnderTestContext.tearDownAll();
+    }
+
+    @Test
+    public void onAfterNavigation_chainIsEmpty_allDestroyed() {
+        afterNavigationTrigger.fire(event);
+
+        assertEquals("", group1.get().getState());
+        assertEquals("", memberOfGroup1.get().getState());
+        assertEquals("", group2.get().getState());
+    }
+
+    @Test
+    public void onAfterNavigation_chainDoesNotContainOwner_ownerDestroyedOtherRemained() {
+        chain.add(group1.get());
+        afterNavigationTrigger.fire(event);
+
+        assertEquals(STATE, group1.get().getState());
+        assertEquals(STATE, memberOfGroup1.get().getState());
+        assertEquals("", group2.get().getState());
+    }
+
+    @Test
+    public void onAfterNavigation_chainDoesNotContainOwnerForAssigned_bothDestroyedOtherRemained() {
+        chain.add(group2.get());
+        chain.add(memberOfGroup1.get());
+        afterNavigationTrigger.fire(event);
+
+        assertEquals("", group1.get().getState());
+        assertEquals("", memberOfGroup1.get().getState());
+        assertEquals(STATE, group2.get().getState());
+    }
+
+}


### PR DESCRIPTION
Implementation of ```@RouteScoped```, and ```@NormalRouteScoped``` contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/256)
<!-- Reviewable:end -->
