### PR TITLE
Deployment validation for route scoped context

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
@@ -16,7 +16,13 @@
 
 package com.vaadin.cdi;
 
+import com.vaadin.cdi.annotation.NormalRouteScoped;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.Annotated;
@@ -29,29 +35,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NON_ROUTE_SCOPED_HAVE_OWNER;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NORMAL_SCOPED_COMPONENT;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.OWNER_IS_NOT_ROUTE_COMPONENT;
+
 @Dependent
 class DeploymentValidator {
-
-    @Inject
-    private BeanManager beanManager;
-
-    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
-        infoSet.forEach(info -> validateBean(info).ifPresent(addDeploymentProblem));
-    }
-
-    private Optional<DeploymentProblem> validateBean(BeanInfo beanInfo) {
-        if (!beanInfo.isComponent()) {
-            return Optional.empty();
-        }
-        if (beanManager.isNormalScope(beanInfo.getScope())) {
-            Type baseType = beanInfo.getBaseType();
-            return Optional.of(new DeploymentProblem(String.format(
-                    "Normal scoped Vaadin components are not supported. " +
-                            "Should not belong to a normal scope: class '%s'",
-                    baseType.getTypeName()), baseType));
-        }
-        return Optional.empty();
-    }
 
     static class BeanInfo {
 
@@ -73,13 +64,21 @@ class DeploymentValidator {
 
         private boolean isComponent() {
             for (Type type : bean.getTypes()) {
-                if (type instanceof Class) {
-                    if (Component.class.isAssignableFrom((Class) type)) {
-                        return true;
-                    }
+                if (type instanceof Class
+                        && Component.class.isAssignableFrom((Class) type)) {
+                    return true;
                 }
             }
             return false;
+        }
+
+        private Optional<RouteScopeOwner> getRouteScopeOwner() {
+            for (Annotation ann : bean.getQualifiers()) {
+                if (ann instanceof RouteScopeOwner) {
+                    return Optional.of((RouteScopeOwner) ann);
+                }
+            }
+            return Optional.empty();
         }
 
     }
@@ -91,21 +90,120 @@ class DeploymentValidator {
      */
     static class DeploymentProblem extends Throwable {
 
-        private final Type baseType;
+        enum ErrorCode {
+            NORMAL_SCOPED_COMPONENT,
+            NON_ROUTE_SCOPED_HAVE_OWNER,
+            ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
+            OWNER_IS_NOT_ROUTE_COMPONENT
+        }
 
-        private DeploymentProblem(String message, Type baseType) {
+        private final Type baseType;
+        private final ErrorCode errorCode;
+
+        private DeploymentProblem(String message, Type baseType, ErrorCode errorCode) {
             super(message);
             this.baseType = baseType;
+            this.errorCode = errorCode;
         }
 
         /**
          * For testing purposes only.
+         *
          * @return annotated base type of the invalid bean
          */
         Type getBaseType() {
             return baseType;
         }
 
+        /**
+         * For testing purposes only.
+         *
+         * @return errorCode of the invalid bean
+         */
+        ErrorCode getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    private class BeanValidator {
+
+        private final BeanInfo beanInfo;
+        private final Consumer<Throwable> problemConsumer;
+
+        private BeanValidator(BeanInfo beanInfo, Consumer<Throwable> problemConsumer) {
+            this.beanInfo = beanInfo;
+            this.problemConsumer = problemConsumer;
+        }
+
+        private void validate() {
+            Class<? extends Annotation> scope = beanInfo.getScope();
+            Optional<RouteScopeOwner> owner = beanInfo.getRouteScopeOwner();
+            Type baseType = beanInfo.getBaseType();
+
+            if (beanInfo.isComponent() && beanManager.isNormalScope(scope)) {
+                addProblem(NORMAL_SCOPED_COMPONENT,
+                        "Normal scoped Vaadin components are not supported. " +
+                        "'%s' should not belong to a normal scope.",
+                        baseType.getTypeName()
+                );
+            }
+
+            if (scope.equals(RouteScoped.class) || scope.equals(NormalRouteScoped.class)) {
+                if (owner.isPresent()) {
+                    if (isNonRouteComponent(owner.get().value())) {
+                        addProblem(OWNER_IS_NOT_ROUTE_COMPONENT,
+                                "'@%s' should define a route component on '%s'.",
+                                RouteScopeOwner.class.getSimpleName(),
+                                baseType.getTypeName()
+                        );
+                    }
+                } else {
+                    if (isNonRouteComponent(baseType)) {
+                        addProblem(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
+                                "'%s' is not a route component, need a '@%s'.",
+                                baseType.getTypeName(),
+                                RouteScopeOwner.class.getSimpleName()
+                        );
+                    }
+                }
+            } else {
+                if (owner.isPresent()) {
+                    addProblem(NON_ROUTE_SCOPED_HAVE_OWNER,
+                            "'%s' should be '@%s' or '@%s' to have a '@%s'.",
+                            baseType.getTypeName(),
+                            RouteScoped.class.getSimpleName(),
+                            NormalRouteScoped.class.getSimpleName(),
+                            RouteScopeOwner.class.getSimpleName()
+                    );
+                }
+            }
+        }
+
+        private void addProblem(ErrorCode errorCode, String message, Object... param) {
+            Type baseType = beanInfo.getBaseType();
+            String desc = String.format(message, param);
+            problemConsumer.accept(new DeploymentProblem(desc, baseType, errorCode));
+        }
+
+        private boolean isNonRouteComponent(Type type) {
+            if (!(type instanceof Class)) {
+                return true;
+            }
+            Class clazz = (Class) type;
+            // RouteRegistry contains filtered route targets,
+            // but we want to ignore filters here.
+            return !clazz.isAnnotationPresent(Route.class)
+                    && !HasErrorParameter.class.isAssignableFrom(clazz)
+                    && !RouterLayout.class.isAssignableFrom(clazz);
+        }
+
+    }
+
+    @Inject
+    private BeanManager beanManager;
+
+    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> problemConsumer) {
+        infoSet.forEach(info -> new BeanValidator(info, problemConsumer).validate());
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -156,8 +156,12 @@ public class DeploymentValidatorTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             ProblemId problemId = (ProblemId) o;
             return errorCode == problemId.errorCode &&
                     Objects.equals(baseType, problemId.baseType);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -16,13 +16,28 @@
 
 package com.vaadin.cdi;
 
+import com.vaadin.cdi.DeploymentValidator.BeanInfo;
+import com.vaadin.cdi.DeploymentValidator.DeploymentProblem;
+import com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode;
+import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.NormalUIScoped;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Vetoed;
@@ -32,12 +47,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NON_ROUTE_SCOPED_HAVE_OWNER;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NORMAL_SCOPED_COMPONENT;
+import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.OWNER_IS_NOT_ROUTE_COMPONENT;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(CdiTestRunner.class)
 public class DeploymentValidatorTest {
@@ -58,53 +79,206 @@ public class DeploymentValidatorTest {
     public static class ProducedNormalScopedComponent extends Component {
     }
 
+    @RouteScopeOwner(RouteTargetOfSelf.class)
+    public static class NonRouteScopedHaveOwner {
+    }
+
+    @RouteScopeOwner(PseudoScopedLabel.class)
+    @RouteScoped
+    public static class OwnerIsNotRouteComponent {
+    }
+
+    @RouteScoped
+    public static class AbsentOwnerOfNonRouteComponent {
+    }
+
+    @Route
+    @RouteScoped
+    @RouteScopeOwner(RouteTargetOfSelf.class)
+    public static class RouteTargetOfSelf extends Label {
+    }
+
+    @Route
+    @RouteScoped
+    public static class TestRouteScopedTarget extends Label {
+    }
+
+    @RouteScoped
+    public static class TestRouterLayout extends Label implements RouterLayout {
+    }
+
+    @RouteScoped
+    public static class TestHasErrorParameter extends Label implements HasErrorParameter<NullPointerException> {
+        @Override
+        public int setErrorParameter(BeforeEnterEvent event, ErrorParameter<NullPointerException> parameter) {
+            return 0;
+        }
+    }
+
+    @RouteScopeOwner(RouteTargetOfSelf.class)
+    @RouteScoped
+    public static class BeanOfRouteTarget {
+    }
+
+    @RouteScopeOwner(TestRouterLayout.class)
+    @RouteScoped
+    public static class BeanOfRouterLayout {
+    }
+
+    @RouteScopeOwner(TestRouterLayout.class)
+    @RouteScoped
+    @Route(layout = TestRouterLayout.class)
+    public static class RouteTargetOfRouterLayout {
+    }
+
+    @RouteScopeOwner(TestHasErrorParameter.class)
+    @RouteScoped
+    public static class BeanOfHasErrorParameter {
+    }
+
+    @Vetoed
+    public static class ProducedRouteScopedBeanWithoutOwner {
+    }
+
+    private static class ProblemId {
+        private final ErrorCode errorCode;
+        private final Type baseType;
+
+        private ProblemId(DeploymentProblem problem) {
+            this.errorCode = problem.getErrorCode();
+            this.baseType = problem.getBaseType();
+        }
+
+        private ProblemId(ErrorCode errorCode, Type baseType) {
+            this.errorCode = errorCode;
+            this.baseType = baseType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ProblemId problemId = (ProblemId) o;
+            return errorCode == problemId.errorCode &&
+                    Objects.equals(baseType, problemId.baseType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(errorCode, baseType);
+        }
+
+        @Override
+        public String toString() {
+            return "ProblemId{" +
+                    "errorCode=" + errorCode +
+                    ", baseType=" + baseType +
+                    '}';
+        }
+    }
+
     @Inject
     private TestDeploymentValidator validator;
 
     @Inject
     private TestDeploymentValidator.BeanInfoSetHolder beanInfoSetHolder;
 
+    private List<Throwable> problems;
+
+    @Before
+    public void setUp() {
+        problems = new ArrayList<>();
+    }
+
+    @After
+    public void tearDown() {
+        problems.forEach(problem -> getLogger().error(problem.getMessage()));
+    }
+
     @Test
-    public void validate_multipleNormalScopedProblems_collected() {
-        Set<DeploymentValidator.BeanInfo> infoSet = createBeanSet(
+    public void validate_normalScopedProblems_collected() {
+        Set<BeanInfo> infoSet = createBeanSet(
                 PseudoScopedLabel.class,
                 NormalScopedBean.class,
                 NormalScopedLabel.class,
                 ProducedNormalScopedComponent.class);
 
-        List<Throwable> problems = new ArrayList<>();
         validator.validateForTest(infoSet, problems::add);
 
         assertEquals(2, problems.size());
-
-        Set<Type> types = problems.stream()
-                .map(info -> ((DeploymentValidator.DeploymentProblem) info).getBaseType())
-                .collect(Collectors.toSet());
-
-        assertTrue(types.contains(NormalScopedLabel.class));
-        assertTrue(types.contains(ProducedNormalScopedComponent.class));
+        assertProblemExists(NORMAL_SCOPED_COMPONENT, NormalScopedLabel.class);
+        assertProblemExists(NORMAL_SCOPED_COMPONENT, ProducedNormalScopedComponent.class);
     }
 
-    private Set<DeploymentValidator.BeanInfo> createBeanSet(Type... clazz) {
-        Map<Type, DeploymentValidator.BeanInfo> map = getBeanInfoSetAsMap();
+    @Test
+    public void validate_routeScopedProblems_collected() {
+        Set<BeanInfo> infoSet = createBeanSet(
+                NonRouteScopedHaveOwner.class,
+                OwnerIsNotRouteComponent.class,
+                AbsentOwnerOfNonRouteComponent.class,
+                RouteTargetOfSelf.class,
+                TestRouteScopedTarget.class,
+                TestRouterLayout.class,
+                TestHasErrorParameter.class,
+                BeanOfHasErrorParameter.class,
+                BeanOfRouterLayout.class,
+                BeanOfRouteTarget.class,
+                RouteTargetOfRouterLayout.class,
+                ProducedRouteScopedBeanWithoutOwner.class);
+
+        validator.validateForTest(infoSet, problems::add);
+
+        assertEquals(4, problems.size());
+        assertProblemExists(OWNER_IS_NOT_ROUTE_COMPONENT,
+                OwnerIsNotRouteComponent.class);
+        assertProblemExists(NON_ROUTE_SCOPED_HAVE_OWNER,
+                NonRouteScopedHaveOwner.class);
+        assertProblemExists(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
+                AbsentOwnerOfNonRouteComponent.class);
+        assertProblemExists(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
+                ProducedRouteScopedBeanWithoutOwner.class);
+    }
+
+    private void assertProblemExists(ErrorCode errorCode, Type baseType) {
+        ProblemId expected = new ProblemId(errorCode, baseType);
+        boolean match = problems.stream()
+                .map(info -> new ProblemId((DeploymentProblem) info))
+                .anyMatch(Predicate.isEqual(expected));
+        if (!match) {
+            fail("Problem does not exist: " + expected);
+        }
+    }
+
+    private Set<BeanInfo> createBeanSet(Type... clazz) {
+        Map<Type, BeanInfo> map = getBeanInfoSetAsMap();
         return Arrays
                 .stream(clazz)
                 .map(map::get)
                 .collect(Collectors.toSet());
     }
 
-    private Map<Type, DeploymentValidator.BeanInfo> getBeanInfoSetAsMap() {
+    private Map<Type, BeanInfo> getBeanInfoSetAsMap() {
         return beanInfoSetHolder.getInfoSet().stream()
                 // Weld causes duplicate key because of exposing weird things as Object.
                 // Tests are not interested in it.
                 .filter(beanInfo -> !beanInfo.getBaseType().equals(Object.class))
-                .collect(Collectors.toMap(DeploymentValidator.BeanInfo::getBaseType, Function.identity()));
+                .collect(Collectors.toMap(BeanInfo::getBaseType, Function.identity()));
     }
 
     @Produces
     @NormalUIScoped
     private ProducedNormalScopedComponent getProducedComponent() {
         return new ProducedNormalScopedComponent();
+    }
+
+    @Produces
+    @NormalRouteScoped
+    private ProducedRouteScopedBeanWithoutOwner getProducedRouteScopedBeanWithoutOwner() {
+        return new ProducedRouteScopedBeanWithoutOwner();
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(DeploymentValidatorTest.class);
     }
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/TestDeploymentValidator.java
@@ -47,15 +47,15 @@ class TestDeploymentValidator extends DeploymentValidator {
     private BeanInfoSetHolder beanInfoSetHolder;
 
     @Override
-    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
+    void validate(Set<BeanInfo> infoSet, Consumer<Throwable> problemConsumer) {
         // No-op.
         // We need CDI to startup in Unit tests even with
         // intentionally misconfigured beans.
         beanInfoSetHolder.setInfoSet(infoSet);
     }
 
-    void validateForTest(Set<BeanInfo> infoSet, Consumer<Throwable> addDeploymentProblem) {
-        super.validate(infoSet, addDeploymentProblem);
+    void validateForTest(Set<BeanInfo> infoSet, Consumer<Throwable> problemConsumer) {
+        super.validate(infoSet, problemConsumer);
     }
 
 }


### PR DESCRIPTION
Some basic validation of ```@RouteScopeOwner```
- ```@RouteScopeOwner``` value have to be a route component
- A bean qualified by ```@RouteScopeOwner``` have to be ```@RouteScoped``` or ```@NormalRouteScoped```
- ```@RouteScopeOwner``` is mandatory on a ```@RouteScoped``` or ```@NormalRouteScoped``` non route component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/257)
<!-- Reviewable:end -->
