### PR TITLE
Integration test to show push behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
                 <version>1.2</version>
             </dependency>
             <dependency>
+                <groupId>javax.enterprise.concurrent</groupId>
+                <artifactId>javax.enterprise.concurrent-api</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.openwebbeans</groupId>
                 <artifactId>openwebbeans-impl</artifactId>
                 <version>${owb.version}</version>

--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>javax.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.enterprise.concurrent</groupId>
+            <artifactId>javax.enterprise.concurrent-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Vaadin flow -->
         <dependency>

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.push;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.cdi.annotation.UIScoped;
+import com.vaadin.cdi.annotation.VaadinServiceScoped;
+import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import org.apache.deltaspike.core.util.ContextUtils;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import java.lang.annotation.Annotation;
+
+public class PushComponent extends Div {
+
+    public static final String RUN_BACKGROUND = "RUN_BACKGROUND";
+    public static final String RUN_FOREGROUND = "RUN_FOREGROUND";
+
+    private class ContextCheckTask implements Runnable {
+
+        private final UI ui;
+
+        private ContextCheckTask(UI ui) {
+            this.ui = ui;
+        }
+
+        @Override
+        public void run() {
+            try {
+                // Needed to make sure that this is sent as a push message
+                Thread.sleep(500);
+            } catch (InterruptedException exception) {
+            }
+            ui.access(PushComponent.this::print);
+        }
+
+    }
+
+    @Resource
+    private ManagedThreadFactory threadFactory;
+
+    private void print() {
+        printContextIsActive(RequestScoped.class);
+        printContextIsActive(SessionScoped.class);
+        printContextIsActive(ApplicationScoped.class);
+        printContextIsActive(UIScoped.class);
+        printContextIsActive(RouteScoped.class);
+        printContextIsActive(VaadinServiceScoped.class);
+        printContextIsActive(VaadinSessionScoped.class);
+    }
+
+    private void printContextIsActive(Class<? extends Annotation> scope) {
+        Label label = new Label(ContextUtils.isContextActive(scope) + "");
+        label.setId(scope.getName());
+        add(new Div(new Label(scope.getSimpleName() + ": "), label));
+    }
+
+    @PostConstruct
+    private void init() {
+        NativeButton bgButton = new NativeButton("background", event -> {
+            ContextCheckTask task = new ContextCheckTask(UI.getCurrent());
+            Thread thread = threadFactory.newThread(task);
+            thread.start();
+        });
+        bgButton.setId(RUN_BACKGROUND);
+
+        NativeButton fgButton = new NativeButton("foreground", event
+                -> print());
+        fgButton.setId(RUN_FOREGROUND);
+
+        add(bgButton, fgButton);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
@@ -33,6 +33,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.context.SessionScoped;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.locks.Lock;
 
 public class PushComponent extends Div {
 
@@ -49,11 +50,12 @@ public class PushComponent extends Div {
 
         @Override
         public void run() {
-            try {
-                // Needed to make sure that this is sent as a push message
-                Thread.sleep(500);
-            } catch (InterruptedException exception) {
-            }
+            // We can acquire the lock after the request started this thread is processed
+            // Needed to make sure that this is sent as a push message
+            Lock lockInstance = ui.getSession().getLockInstance();
+            lockInstance.lock();
+            lockInstance.unlock();
+
             ui.access(PushComponent.this::print);
         }
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketPushView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketPushView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.push;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.ui.Transport;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@Route("websocket")
+@Push(transport = Transport.WEBSOCKET)
+public class WebsocketPushView extends Div {
+
+    @Inject
+    private PushComponent pushComponent;
+
+    @PostConstruct
+    private void init() {
+        add(pushComponent);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketXhrPushView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketXhrPushView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.push;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.ui.Transport;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@Route("websocket-xhr")
+@Push(transport = Transport.WEBSOCKET_XHR)
+public class WebsocketXhrPushView extends Div {
+
+    @Inject
+    private PushComponent pushComponent;
+
+    @PostConstruct
+    private void init() {
+        add(pushComponent);
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.cdi.annotation.UIScoped;
+import com.vaadin.cdi.annotation.VaadinServiceScoped;
+import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.cdi.itest.push.PushComponent;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import java.lang.annotation.Annotation;
+
+public class PushTest extends AbstractCdiTest {
+
+    @Deployment(testable = false)
+    public static WebArchive deployment() {
+        return ArchiveProvider.createWebArchive("push", webArchive
+                -> webArchive.addPackage(PushComponent.class.getPackage()));
+    }
+
+    @Test
+    public void wsWithXhrBackgroundRequestAndSessionDoesNotActive() {
+        getDriver().get(getTestURL() + "websocket-xhr");
+        click(PushComponent.RUN_BACKGROUND);
+        waitForPush();
+        assertAllExceptRequestAndSessionActive();
+    }
+
+    @Test
+    public void wsWithXhrForegroundAllContextsActive() {
+        getDriver().get(getTestURL() + "websocket-xhr");
+        click(PushComponent.RUN_FOREGROUND);
+        assertContextActive(RequestScoped.class, true);
+        assertContextActive(SessionScoped.class, true);
+        assertContextActive(ApplicationScoped.class, true);
+        assertVaadinContextsActive();
+    }
+
+    @Test
+    public void wsNoXhrBackgroundRequestAndSessionDoesNotActive() {
+        getDriver().get(getTestURL() + "websocket");
+        click(PushComponent.RUN_BACKGROUND);
+        waitForPush();
+        assertAllExceptRequestAndSessionActive();
+    }
+
+    @Test
+    public void wsNoXhrForegroundRequestAndSessionDoesNotActive() {
+        getDriver().get(getTestURL() + "websocket");
+        click(PushComponent.RUN_FOREGROUND);
+        assertAllExceptRequestAndSessionActive();
+    }
+
+    private void assertAllExceptRequestAndSessionActive() {
+        assertContextActive(RequestScoped.class, false);
+        assertContextActive(SessionScoped.class, false);
+        assertContextActive(ApplicationScoped.class, true);
+        assertVaadinContextsActive();
+    }
+
+    private void assertVaadinContextsActive() {
+        assertContextActive(RouteScoped.class, true);
+        assertContextActive(UIScoped.class, true);
+        assertContextActive(VaadinSessionScoped.class, true);
+        assertContextActive(VaadinServiceScoped.class, true);
+    }
+
+    private void assertContextActive(Class<? extends Annotation> scope,
+                                     boolean active) {
+        assertTextEquals(active + "", scope.getName());
+    }
+
+    private void waitForPush() {
+        waitForElementPresent(By.id(RequestScoped.class.getName()));
+    }
+}


### PR DESCRIPTION
Testing wich CDI contexts are active from a foreground ( event handler ) thread, and from a background thread.
The goal was to test how CDI and websocket works together.
Tested transport modes are `WEBSOCKET_XHR`, and `WEBSOCKET`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/259)
<!-- Reviewable:end -->
