### PR TITLE
Bump the major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,8 @@
         <version>2.0.1</version>
     </parent>
 
-    <groupId>com.vaadin</groupId>
     <artifactId>vaadin-cdi-parent</artifactId>
-    <version>10.2-SNAPSHOT</version>
+    <version>11.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>vaadin-cdi-parent</name>

--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cdi-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cdi-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-cdi</artifactId>


### PR DESCRIPTION
We do this for other projects, plus, due to SemVer, since Flow version was bumped to a new major, we need to bump the plugin's major either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/290)
<!-- Reviewable:end -->
