### PR TITLE
Cherry-pick: Add usage statistics

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiVaadinServletService.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiVaadinServletService.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.PollEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationListener;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -125,6 +126,7 @@ public class CdiVaadinServletService extends VaadinServletService {
         addSessionInitListener(this::sessionInit);
         addSessionDestroyListener(this::sessionDestroy);
         addServiceDestroyListener(this::fireCdiDestroyEvent);
+        UsageStatistics.markAsUsed("flow/CdiInstantiator", null);
         super.init();
     }
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceTest.java
@@ -20,6 +20,7 @@ import com.vaadin.cdi.annotation.VaadinServiceEnabled;
 import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.cdi.context.ServiceUnderTestContext;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.CustomizedSystemMessages;
 import com.vaadin.flow.server.DefaultSystemMessagesProvider;
 import com.vaadin.flow.server.ServiceException;
@@ -28,6 +29,7 @@ import com.vaadin.flow.server.SystemMessagesInfo;
 import com.vaadin.flow.server.SystemMessagesProvider;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,7 +40,9 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
@@ -135,6 +139,16 @@ public class CdiVaadinServletServiceTest {
         initServiceWithoutBeanFor(SystemMessagesProvider.class);
         assertThat(service.getSystemMessagesProvider(),
                 instanceOf(DefaultSystemMessagesProvider.class));
+    }
+
+    @Test
+    public void init_callsUsageStatistics() throws ServiceException  {
+        initService(beanManager);
+        List<UsageStatistics.UsageEntry> entries = UsageStatistics.getEntries().filter(entry -> entry.getName().contains("Cdi")).collect(Collectors.toList());
+        Assert.assertEquals(1, entries.size());
+
+        UsageStatistics.UsageEntry entry = entries.get(0);
+        Assert.assertEquals("flow/CdiInstantiator", entry.getName());
     }
 
     private void initService(BeanManager beanManager) throws ServiceException {


### PR DESCRIPTION
Adopted original PR in master (11.2) to report from servlet service instead of instantiator since the latter could be overridden in 11.0.
Should have maybe done the same for the original PR in master, but this should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/308)
<!-- Reviewable:end -->
