### PR TITLE
Add apache-tomee:webprofile dependency to vaadin-cdi-itest

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -130,12 +130,23 @@
     <profiles>
         <profile>
             <id>tomee</id>
+            <properties>
+                <apache-tomee.version>7.0.4</apache-tomee.version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.tomee</groupId>
                     <artifactId>arquillian-tomee-remote</artifactId>
-                    <version>7.0.4</version>
+                    <version>${apache-tomee.version}</version>
                     <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.tomee</groupId>
+                    <artifactId>apache-tomee</artifactId>
+                    <version>${apache-tomee.version}</version>
+                    <scope>test</scope>
+                    <classifier>webprofile</classifier>
+                    <type>zip</type>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
It should fix the error in SNAPSHOT build. See [the build log](https://bender.vaadin.com/viewLog.html?buildId=118043&buildTypeId=Flow_AddOns_FlowCdi22).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/317)
<!-- Reviewable:end -->
