### PR TITLE
Generate effective pom for JBoss shrinkwrap war packaging

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -125,6 +125,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!--
+                JBoss shrinkwrap archive provider builds war based on pom file,
+                so generate effective pom to record any command-line property
+                overrides.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-help-plugin</artifactId>
+                <configuration>
+                    <output>${project.build.directory}/effective-pom.xml</output>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>effective-pom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/ArchiveProvider.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/ArchiveProvider.java
@@ -44,7 +44,7 @@ public class ArchiveProvider {
 
     private static WebArchive base(String warName) {
         PomEquippedResolveStage pom = Maven.configureResolver().workOffline()
-                .loadPomFromFile("pom.xml");
+                .loadPomFromFile("target/effective-pom.xml");
         return ShrinkWrap.create(WebArchive.class, warName + ".war")
                 .addAsLibraries(pom.resolve("com.vaadin:vaadin-cdi")
                         .withTransitivity().asFile())


### PR DESCRIPTION
When packaging war for IT, JBoss shrinkwrap got dependencies from `vaadin-cdi-itest/pom.xml`. This loaded the wrong version when running Maven with property override affecting Flow version (`vaadin.flow.version`). Added a step that generates the effective pom and use that in IT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/330)
<!-- Reviewable:end -->
