### PR TITLE
Pin webcomponentsjs version to 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
                 <artifactId>polymer</artifactId>
                 <version>2.6.0</version>
             </dependency>
+	        <dependency>
+	            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+	            <artifactId>webcomponentsjs</artifactId>
+	            <version>1.2.2</version>
+	        </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
Fix failing build of CDI 10.0 for Flow 1.0 with Chrome 80+

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/cdi/340)
<!-- Reviewable:end -->
