### PR TITLE
remove out-of-scope components from parent

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -22,6 +22,7 @@ import org.apache.deltaspike.core.util.context.ContextualStorage;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
 
 import javax.annotation.PreDestroy;
@@ -111,7 +112,9 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
             if( maybeRouterLayout.isPresent( ) )
                 return;
         }
-        willBeRemoved.getElement( ).removeFromParent( );
+        Element element = willBeRemoved.getElement( );
+        if(element != null)
+            element.removeFromParent( );
     }
 
     protected Set<K> getKeySet() {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -98,7 +98,7 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
         }
     }
 	
-	protected void decouple( HasElement willBeRemoved) {
+    protected void decouple( HasElement willBeRemoved) {
         if(willBeRemoved instanceof Component ) {
             Component c = (Component)willBeRemoved;
             Optional<RouterLayout> maybeRouterLayout = c.getParent()
@@ -108,8 +108,9 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
             if(maybeRouterLayout.isPresent())
                 return;
         }
-        willBeRemoved.getElement().removeFromParent();
-	}
+        if(willBeRemoved.getElement() != null)
+            willBeRemoved.getElement().removeFromParent();
+    }
 
 
     protected Set<K> getKeySet() {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -97,21 +97,31 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
             AbstractContext.destroyAllActive(storage);
         }
     }
-	
-    protected void decouple( HasElement willBeRemoved) {
-        if(willBeRemoved instanceof Component ) {
-            Component c = (Component)willBeRemoved;
-            Optional<RouterLayout> maybeRouterLayout = c.getParent()
-                .filter(RouterLayout.class::isInstance)
-                .map(RouterLayout.class::cast);
-            maybeRouterLayout.ifPresent(rl -> rl.removeRouterLayoutContent(willBeRemoved));
-            if(maybeRouterLayout.isPresent())
-                return;
-        }
-        if(willBeRemoved.getElement() != null)
-            willBeRemoved.getElement().removeFromParent();
-    }
 
+    protected void decouple(HasElement willBeRemoved)
+    {
+        Element elementToRemove = willBeRemoved.getElement( );
+        if( elementToRemove != null )
+        {
+            Node<?> parent = elementToRemove.getParentNode( );
+            if( parent != null && parent.getChildren( ).anyMatch( n -> n == elementToRemove ) )
+            {
+                if( willBeRemoved instanceof Component )
+                {
+                    Component c = (Component) willBeRemoved;
+                    Optional<RouterLayout> maybeRouterLayout = c.getParent( )
+                            .filter( RouterLayout.class::isInstance )
+                            .map( RouterLayout.class::cast );
+                    maybeRouterLayout
+                            .ifPresent( rl -> rl.removeRouterLayoutContent( willBeRemoved ) );
+                    if( maybeRouterLayout.isPresent( ) )
+                        return;
+                }
+                elementToRemove.removeFromParent( );
+                // NOTE: it seems removeFromParent does not set getParent to null
+            }
+        }
+    }
 
     protected Set<K> getKeySet() {
         return Collections.unmodifiableSet(storageMap.keySet());

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -22,8 +22,6 @@ import org.apache.deltaspike.core.util.context.ContextualStorage;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
-import com.vaadin.flow.dom.Node;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
 
 import javax.annotation.PreDestroy;
@@ -102,27 +100,18 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
 
     protected void decouple(HasElement willBeRemoved)
     {
-        Element elementToRemove = willBeRemoved.getElement( );
-        if( elementToRemove != null )
+        if( willBeRemoved instanceof Component )
         {
-            Node<?> parent = elementToRemove.getParentNode( );
-            if( parent != null && parent.getChildren( ).anyMatch( n -> n == elementToRemove ) )
-            {
-                if( willBeRemoved instanceof Component )
-                {
-                    Component c = (Component) willBeRemoved;
-                    Optional<RouterLayout> maybeRouterLayout = c.getParent( )
-                            .filter( RouterLayout.class::isInstance )
-                            .map( RouterLayout.class::cast );
-                    maybeRouterLayout
-                            .ifPresent( rl -> rl.removeRouterLayoutContent( willBeRemoved ) );
-                    if( maybeRouterLayout.isPresent( ) )
-                        return;
-                }
-                elementToRemove.removeFromParent( );
-                // NOTE: it seems removeFromParent does not set getParent to null
-            }
+            Component c = (Component) willBeRemoved;
+            Optional<RouterLayout> maybeRouterLayout = c.getParent( )
+                    .filter( RouterLayout.class::isInstance )
+                    .map( RouterLayout.class::cast );
+            maybeRouterLayout
+                    .ifPresent( rl -> rl.removeRouterLayoutContent( willBeRemoved ) );
+            if( maybeRouterLayout.isPresent( ) )
+                return;
         }
+        willBeRemoved.getElement( ).removeFromParent( );
     }
 
     protected Set<K> getKeySet() {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -22,6 +22,8 @@ import org.apache.deltaspike.core.util.context.ContextualStorage;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.Node;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
 
 import javax.annotation.PreDestroy;


### PR DESCRIPTION
When HasElements / Components are out of scope they are destroyed, but are not removed from their parents. In case of UIScoped parent layouts with RouteScoped router content for example, this will result in these elements remaining in the component tree with undesirable results. This change checks if objects that will become out of scope and should be destroyed are Component or HasElement and will remove them from their parent to ensure they can ultimately be garbage collected.

This pull request is associated to issue #345 and related to issue #324 