### PR TITLE
chore: Update Flow version to 5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
 
-        <vaadin.flow.version>4.0-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>5.0-SNAPSHOT</vaadin.flow.version>
         <slf4j.version>1.7.25</slf4j.version>
         <deltaspike.version>1.8.1</deltaspike.version>
         <owb.version>1.7.5</owb.version>


### PR DESCRIPTION
As the master Flow is at `5.0-SNAPSHOT`, this change updates the version in `pom.xml` accordingly.