### PR TITLE
feat: reimplement @RouteScoped to keep beans for PreserveOnRefresh

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/AbstractCountedView.java
@@ -16,10 +16,10 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.html.Div;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+
+import com.vaadin.flow.component.html.Div;
 
 public abstract class AbstractCountedView extends Div implements CountedPerUI {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/BeanNoOwner.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/BeanNoOwner.java
@@ -13,12 +13,17 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.cdi.context;
+package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
+import java.util.UUID;
 
-@Tag(Tag.A)
-class TestNavigationTarget extends Component {
+import com.vaadin.cdi.annotation.RouteScoped;
+
+@RouteScoped
+public class BeanNoOwner extends AbstractCountedBean {
+
+    public BeanNoOwner() {
+        setData(UUID.randomUUID().toString());
+    }
 
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ChildNoOwnerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ChildNoOwnerView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+@Route(value = "child-no-owner", layout = ParentNoOwnerView.class)
+public class ChildNoOwnerView extends Div {
+
+    @Inject
+    private Instance<BeanNoOwner> instance;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        if (attachEvent.isInitialAttach()) {
+            RouterLink link = new RouterLink("parent", ParentNoOwnerView.class);
+            link.setId("to-parent");
+            add(link);
+
+            Div div = new Div();
+            div.setId("child-info");
+            div.getElement().getStyle().set("display", "block");
+            div.setText(instance.get().getData());
+            add(div);
+
+            NativeButton button = new NativeButton("Reset bean instance",
+                    event -> div.setText(instance.get().getData()));
+            add(button);
+            button.setId("reset");
+        }
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomException.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomException.java
@@ -13,12 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.cdi.context;
+package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
-
-@Tag(Tag.A)
-class TestNavigationTarget extends Component {
+public class CustomException extends RuntimeException {
 
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubButton.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubButton.java
@@ -13,12 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.cdi.context;
+package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
+import java.util.UUID;
 
-@Tag(Tag.A)
-class TestNavigationTarget extends Component {
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.NativeButton;
 
+@RouteScoped
+@RouteScopeOwner(ErrorHandlerView.class)
+public class CustomExceptionSubButton extends AbstractCountedView {
+
+    public CustomExceptionSubButton() {
+        NativeButton button = new NativeButton();
+        button.setId("custom-exception-button");
+        button.setText(UUID.randomUUID().toString());
+        add(button);
+    }
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubDiv.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubDiv.java
@@ -13,12 +13,19 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.cdi.context;
+package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
+import java.util.UUID;
 
-@Tag(Tag.A)
-class TestNavigationTarget extends Component {
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
 
+@RouteScoped
+@RouteScopeOwner(ErrorHandlerView.class)
+public class CustomExceptionSubDiv extends AbstractCountedView {
+
+    public CustomExceptionSubDiv() {
+        setId("custom-exception-div");
+        setText(UUID.randomUUID().toString());
+    }
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
@@ -16,30 +16,60 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletResponse;
+
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.RouterLink;
 
-import javax.servlet.http.HttpServletResponse;
-
 @RouteScoped
 @RouteScopeOwner(ErrorParentView.class)
 @ParentLayout(ErrorParentView.class)
 public class ErrorHandlerView extends AbstractCountedView
-        implements HasErrorParameter<NullPointerException> {
+        implements HasErrorParameter<CustomException> {
 
     public static final String PARENT = "parent";
 
+    @Inject
+    @RouteScopeOwner(ErrorHandlerView.class)
+    private Instance<CustomExceptionSubButton> buttonInjection;
+
+    @Inject
+    @RouteScopeOwner(ErrorHandlerView.class)
+    private Instance<CustomExceptionSubDiv> divInjection;
+
+    private boolean isSubDiv;
+
+    private Component current;
+
     @Override
     public int setErrorParameter(BeforeEnterEvent event,
-                                 ErrorParameter<NullPointerException> parameter) {
-        add(
-                new RouterLink(PARENT, ErrorParentView.class)
-        );
+            ErrorParameter<CustomException> parameter) {
+        add(new RouterLink(PARENT, ErrorParentView.class));
+
+        NativeButton button = new NativeButton("switch content", ev -> {
+            remove(current);
+            if (isSubDiv) {
+                current = buttonInjection.get();
+            } else {
+                current = divInjection.get();
+            }
+            add(current);
+            isSubDiv = !isSubDiv;
+        });
+        button.setId("switch-content");
+        add(button);
+        current = buttonInjection.get();
+        add(current);
+
         return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
@@ -16,14 +16,16 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import javax.annotation.PostConstruct;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RouterLink;
 
-import javax.annotation.PostConstruct;
-
 @RouteScoped
+@RouteScopeOwner(ErrorParentView.class)
 @Route("error-layout")
 public class ErrorParentView extends AbstractCountedView
         implements RouterLayout {

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/InvalidView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/InvalidView.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("invalid-injection")
+public class InvalidView extends Div {
+
+    @Inject
+    @RouteScopeOwner(ErrorParentView.class)
+    /*
+     * There is no a ErrorParentView in navigation: this injection has no scope.
+     * Pseudo-scope @RouteScoped is used here with the component to immediately
+     * get an exception, for normal scope proxy is created and the exception
+     * won't be thrown immediately.
+     */
+    private ErrorParentView bean;
+
+    public InvalidView() {
+        setId("invalid-injection");
+        setText("This view should not be shown since the "
+                + "injection has no scope and an exception should be thrown");
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayout.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayout.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+
+public class MainLayout extends Div implements RouterLayout {
+
+    public static final String UIID = "UIID";
+
+    public static final String PRESERVE = "preserve";
+    public static final String INVALID = "invalid";
+    public static final String PARENT_NO_OWNER = "parent-no-owner";
+    public static final String CHILD_NO_OWNER = "child-no-owner";
+
+    private Label uiIdLabel;
+
+    public MainLayout() {
+        add(new RouterLink(PRESERVE, PreserveOnRefreshView.class),
+                new RouterLink(INVALID, InvalidView.class),
+                new RouterLink(PARENT_NO_OWNER, ParentNoOwnerView.class),
+                new RouterLink(CHILD_NO_OWNER, ChildNoOwnerView.class));
+        ;
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        if (uiIdLabel != null) {
+            remove(uiIdLabel);
+        }
+        uiIdLabel = new Label(attachEvent.getUI().getUIId() + "");
+        uiIdLabel.setId(UIID);
+        add(uiIdLabel);
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
@@ -16,6 +16,9 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
@@ -26,9 +29,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RoutePrefix;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RouterLink;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 @RouteScoped
 @Route("")
@@ -44,31 +44,20 @@ public class MasterView extends AbstractCountedView
     @Inject
     @RouteScopeOwner(MasterView.class)
     private AssignedBean assignedBean;
-    @Inject
-    @RouteScopeOwner(DetailApartView.class)
-    private ApartBean apartBean;
     private Label assignedLabel;
-    private Label apartLabel;
 
     @PostConstruct
     private void init() {
         assignedLabel = new Label();
         assignedLabel.setId(ASSIGNED_BEAN_LABEL);
-        apartLabel = new Label();
-        apartLabel.setId(APART_BEAN_LABEL);
-        add(
-                new Label("MASTER"),
-                new Div(assignedLabel),
-                new Div(apartLabel),
+        add(new Label("MASTER"), new Div(assignedLabel),
                 new Div(new RouterLink(ASSIGNED, DetailAssignedView.class)),
-                new Div(new RouterLink(APART, DetailApartView.class))
-        );
+                new Div(new RouterLink(APART, DetailApartView.class)));
     }
 
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
         assignedLabel.setText(assignedBean.getData());
-        apartLabel.setText(apartBean.getData());
     }
 
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ParentNoOwnerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ParentNoOwnerView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.inject.Inject;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+
+@Route("parent-no-owner")
+public class ParentNoOwnerView extends Div implements RouterLayout {
+
+    @Inject
+    private BeanNoOwner bean;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        if (attachEvent.isInitialAttach()) {
+            RouterLink link = new RouterLink("child", ChildNoOwnerView.class);
+            link.setId("to-child");
+            add(link);
+
+            Div div = new Div();
+            div.setId("parent-info");
+            div.getElement().getStyle().set("display", "block");
+            div.setText(bean.getData());
+            add(div);
+        }
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshBean.java
@@ -13,12 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.cdi.context;
+package com.vaadin.cdi.itest.routecontext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
+import javax.annotation.PostConstruct;
 
-@Tag(Tag.A)
-class TestNavigationTarget extends Component {
+import java.util.UUID;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+
+@RouteScoped
+@RouteScopeOwner(PreserveOnRefreshView.class)
+public class PreserveOnRefreshBean extends AbstractCountedBean {
+
+    @PostConstruct
+    private void init() {
+        setData(UUID.randomUUID().toString());
+    }
 
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@PreserveOnRefresh
+@Route(value = "preserve-on-refresh", layout = MainLayout.class)
+public class PreserveOnRefreshView extends Div {
+
+    @Inject
+    @RouteScopeOwner(PreserveOnRefreshView.class)
+    private Instance<PreserveOnRefreshBean> injection;
+
+    public PreserveOnRefreshView() {
+        setId("preserve-on-refresh");
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        setText(injection.get().getData());
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
@@ -16,39 +16,32 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import javax.annotation.PostConstruct;
+
 import com.vaadin.cdi.annotation.RouteScoped;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 
-import javax.annotation.PostConstruct;
-
-@Route("")
+@Route(value = "", layout = MainLayout.class)
 @RouteScoped
 public class RootView extends AbstractCountedView {
 
     public static final String MASTER = "master";
     public static final String REROUTE = "reroute";
     public static final String POSTPONE = "postpone";
-    public static final String UIID = "UIID";
     public static final String EVENT = "event";
     public static final String ERROR = "ERROR";
 
     @PostConstruct
     private void init() {
-        Label uiIdLabel = new Label(UI.getCurrent().getUIId() + "");
-        uiIdLabel.setId(UIID);
-        add(
-                new Div(uiIdLabel),
-                new Div(new Label("ROOT")),
+        add(new Div(new Label("ROOT")),
                 new Div(new RouterLink(MASTER, MasterView.class)),
                 new Div(new RouterLink(REROUTE, RerouteView.class)),
                 new Div(new RouterLink(POSTPONE, PostponeView.class)),
                 new Div(new RouterLink(EVENT, EventView.class)),
-                new Div(new RouterLink(ERROR, ErrorView.class))
-        );
+                new Div(new RouterLink(ERROR, ErrorView.class)));
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
@@ -98,7 +98,7 @@ class DeploymentValidator {
     static class DeploymentProblem extends Throwable {
 
         enum ErrorCode {
-            NORMAL_SCOPED_COMPONENT, NON_ROUTE_SCOPED_HAVE_OWNER, ABSENT_OWNER_OF_NON_ROUTE_COMPONENT, OWNER_IS_NOT_ROUTE_COMPONENT
+            NORMAL_SCOPED_COMPONENT, NON_ROUTE_SCOPED_HAVE_OWNER, OWNER_IS_NOT_ROUTE_COMPONENT
         }
 
         private final Type baseType;

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/DeploymentValidator.java
@@ -16,6 +16,20 @@
 
 package com.vaadin.cdi;
 
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
 import com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode;
 import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
@@ -25,20 +39,6 @@ import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 
-import javax.enterprise.context.Dependent;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-
-import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NON_ROUTE_SCOPED_HAVE_OWNER;
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NORMAL_SCOPED_COMPONENT;
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.OWNER_IS_NOT_ROUTE_COMPONENT;
@@ -92,23 +92,20 @@ class DeploymentValidator {
     }
 
     /**
-     * Represents a deployment problem to be passed to the container.
-     * Message and stacktrace will appear in server log.
-     * It is not thrown, or caught.
+     * Represents a deployment problem to be passed to the container. Message
+     * and stacktrace will appear in server log. It is not thrown, or caught.
      */
     static class DeploymentProblem extends Throwable {
 
         enum ErrorCode {
-            NORMAL_SCOPED_COMPONENT,
-            NON_ROUTE_SCOPED_HAVE_OWNER,
-            ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
-            OWNER_IS_NOT_ROUTE_COMPONENT
+            NORMAL_SCOPED_COMPONENT, NON_ROUTE_SCOPED_HAVE_OWNER, ABSENT_OWNER_OF_NON_ROUTE_COMPONENT, OWNER_IS_NOT_ROUTE_COMPONENT
         }
 
         private final Type baseType;
         private final ErrorCode errorCode;
 
-        private DeploymentProblem(String message, Type baseType, ErrorCode errorCode) {
+        private DeploymentProblem(String message, Type baseType,
+                ErrorCode errorCode) {
             super(message);
             this.baseType = baseType;
             this.errorCode = errorCode;
@@ -159,10 +156,9 @@ class DeploymentValidator {
         @Override
         public String getErrorMessage(BeanInfo beanInfo) {
             return String.format(
-                    "Normal scoped Vaadin components are not supported. " +
-                            "'%s' should not belong to a normal scope.",
-                    beanInfo.getBaseType().getTypeName()
-            );
+                    "Normal scoped Vaadin components are not supported. "
+                            + "'%s' should not belong to a normal scope.",
+                    beanInfo.getBaseType().getTypeName());
         }
 
     }
@@ -172,10 +168,9 @@ class DeploymentValidator {
         @Override
         public boolean isInvalid(BeanInfo beanInfo) {
             return beanInfo.isRouteScoped()
-                    && beanInfo.getRouteScopeOwner()
-                    .map(RouteScopeOwner::value)
-                    .filter(DeploymentValidator::isNonRouteComponent)
-                    .isPresent();
+                    && beanInfo.getRouteScopeOwner().map(RouteScopeOwner::value)
+                            .filter(DeploymentValidator::isNonRouteComponent)
+                            .isPresent();
         }
 
         @Override
@@ -188,33 +183,7 @@ class DeploymentValidator {
             return String.format(
                     "'@%s' should define a route component on '%s'.",
                     RouteScopeOwner.class.getSimpleName(),
-                    beanInfo.getBaseType().getTypeName()
-            );
-        }
-
-    }
-
-    private class AbsentOwnerOfNonRouteComponentValidator implements BeanValidator {
-
-        @Override
-        public boolean isInvalid(BeanInfo beanInfo) {
-            return beanInfo.isRouteScoped()
-                    && isNonRouteComponent(beanInfo.getBaseType())
-                    && !beanInfo.getRouteScopeOwner().isPresent();
-        }
-
-        @Override
-        public ErrorCode getErrorCode() {
-            return ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
-        }
-
-        @Override
-        public String getErrorMessage(BeanInfo beanInfo) {
-            return String.format(
-                    "'%s' is not a route component, need a '@%s'.",
-                    beanInfo.getBaseType().getTypeName(),
-                    RouteScopeOwner.class.getSimpleName()
-            );
+                    beanInfo.getBaseType().getTypeName());
         }
 
     }
@@ -239,8 +208,7 @@ class DeploymentValidator {
                     beanInfo.getBaseType().getTypeName(),
                     RouteScoped.class.getSimpleName(),
                     NormalRouteScoped.class.getSimpleName(),
-                    RouteScopeOwner.class.getSimpleName()
-            );
+                    RouteScopeOwner.class.getSimpleName());
         }
 
     }
@@ -250,22 +218,19 @@ class DeploymentValidator {
 
     private final List<BeanValidator> validators = Arrays.asList(
             new NormalScopedComponentValidator(),
-            new AbsentOwnerOfNonRouteComponentValidator(),
             new OwnerIsNotRouteComponentValidator(),
-            new NonRouteScopedHaveOwnerValidator()
-    );
+            new NonRouteScopedHaveOwnerValidator());
 
     void validate(Set<BeanInfo> infoSet, Consumer<Throwable> problemConsumer) {
         infoSet.forEach(info -> validateBean(info, problemConsumer));
     }
 
-    private void validateBean(BeanInfo beanInfo, Consumer<Throwable> problemConsumer) {
-        validators.stream()
-                .filter(validator -> validator.isInvalid(beanInfo))
+    private void validateBean(BeanInfo beanInfo,
+            Consumer<Throwable> problemConsumer) {
+        validators.stream().filter(validator -> validator.isInvalid(beanInfo))
                 .map(validator -> new DeploymentProblem(
                         validator.getErrorMessage(beanInfo),
-                        beanInfo.getBaseType(),
-                        validator.getErrorCode()))
+                        beanInfo.getBaseType(), validator.getErrorCode()))
                 .forEach(problemConsumer);
     }
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScoped.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/RouteScoped.java
@@ -16,46 +16,49 @@
 
 package com.vaadin.cdi.annotation;
 
-import com.vaadin.flow.router.HasErrorParameter;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouterLayout;
-
 import javax.inject.Scope;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+
 /**
  * The lifecycle of a RouteScoped component is controlled by route navigation.
  * <p>
- * Every RouteScoped bean belongs to one router component owner.
- * It can be a {@link Route @Route}, or a {@link RouterLayout},
- * or a {@link HasErrorParameter HasErrorParameter}.
- * Beans are qualified by {@link RouteScopeOwner @RouteScopeOwner}
- * to link with their owner.
+ * Every RouteScoped bean belongs to one router component owner. It can be a
+ * {@link Route @Route} component, or a {@link RouterLayout}, or a
+ * {@link HasErrorParameter HasErrorParameter}. Beans are qualified by
+ * {@link RouteScopeOwner @RouteScopeOwner} to link with their owner.
  * <p>
  * Until owner remains active, all beans owned by it remain in the scope.
  * <p>
- * When a RouteScoped bean is a router component,
- * an owner can be any ancestor {@link RouterLayout}, or the bean itself.
- * Omitting the RouteScopeOwner annotation means owner is the bean itself.
+ * Without the {@link RouteScopeOwner} annotation the owner is the current route
+ * target component (dynamically calculated). With nested routing hierarchies,
+ * the target is the "leaf" or "bottom most" routing component. The beans are
+ * preserved as long as the owner component remains in the navigation chain. It
+ * means that the bean may be preserved even if the navigation target is changed
+ * (but the "initial" calculated owner is still in the navigation chain).
  * <p>
  * Injection with this annotation will create a direct reference to the object
  * rather than a proxy.
  * <p>
  * There are some limitations when not using proxies. Circular referencing (that
- * is, injecting A to B and B to A) will not work.
- * Injecting into a larger scope will bind the instance
- * from the currently active smaller scope, and will ignore smaller scope change.
- * For example after being injected into session scope it will point to the same
- * RouteScoped bean instance ( even it is destroyed ) regardless of UI,
- * or any navigation change.
+ * is, injecting A to B and B to A) will not work. Injecting into a larger scope
+ * will bind the instance from the currently active smaller scope, and will
+ * ignore smaller scope change. For example after being injected into session
+ * scope it will point to the same RouteScoped bean instance ( even it is
+ * destroyed ) regardless of UI, or any navigation change.
  * <p>
- * The sister annotation to this is the {@link NormalRouteScoped}. Both annotations
- * reference the same underlying scope, so it is possible to get both a proxy
- * and a direct reference to the same object by using different annotations.
+ * The sister annotation to this is the {@link NormalRouteScoped}. Both
+ * annotations reference the same underlying scope, so it is possible to get
+ * both a proxy and a direct reference to the same object by using different
+ * annotations.
  */
 @Scope
 @Inherited

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -16,12 +16,10 @@
 
 package com.vaadin.cdi.context;
 
-import org.apache.deltaspike.core.util.context.AbstractContext;
-import org.apache.deltaspike.core.util.context.ContextualStorage;
-
 import javax.annotation.PreDestroy;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,15 +28,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.deltaspike.core.util.context.AbstractContext;
+import org.apache.deltaspike.core.util.context.ContextualStorage;
+
 /**
  * Base class for manage and store ContextualStorages.
  *
- * This class is responsible for
- * - creating, and providing the ContextualStorage for a context key
- * - destroying ContextualStorages
+ * This class is responsible for - creating, and providing the ContextualStorage
+ * for a context key - destroying ContextualStorages
  */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-abstract class AbstractContextualStorageManager<K> implements Serializable  {
+abstract class AbstractContextualStorageManager<K> implements Serializable {
     @Inject
     private BeanManager beanManager;
     private final boolean concurrent;
@@ -53,7 +53,8 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
         this.concurrent = concurrent;
     }
 
-    protected ContextualStorage getContextualStorage(K key, boolean createIfNotExist) {
+    protected ContextualStorage getContextualStorage(K key,
+            boolean createIfNotExist) {
         if (createIfNotExist) {
             return storageMap.computeIfAbsent(key, this::newContextualStorage);
         } else {
@@ -61,12 +62,20 @@ abstract class AbstractContextualStorageManager<K> implements Serializable  {
         }
     }
 
+    protected void relocate(K from, K to) {
+        ContextualStorage storage = storageMap.remove(from);
+        if (storage != null) {
+            storageMap.put(to, storage);
+        }
+    }
+
     protected ContextualStorage newContextualStorage(K key) {
-        // Not required by the spec, but in reality beans are PassivationCapable.
+        // Not required by the spec, but in reality beans are
+        // PassivationCapable.
         // Even for non serializable bean classes.
         // CDI implementations use PassivationCapable beans,
-        // because injecting non serializable proxies might block serialization of
-        // bean instances in a passivation capable context.
+        // because injecting non serializable proxies might block serialization
+        // of bean instances in a passivation capable context.
         return new ContextualStorage(beanManager, concurrent, true);
     }
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -16,23 +16,40 @@
 
 package com.vaadin.cdi.context;
 
-import com.vaadin.cdi.annotation.NormalUIScoped;
-import com.vaadin.cdi.annotation.RouteScopeOwner;
-import com.vaadin.cdi.annotation.RouteScoped;
-import com.vaadin.flow.router.AfterNavigationEvent;
-import org.apache.deltaspike.core.api.provider.BeanProvider;
-import org.apache.deltaspike.core.util.context.AbstractContext;
-import org.apache.deltaspike.core.util.context.ContextualStorage;
-
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.PassivationCapable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+import org.apache.deltaspike.core.util.context.AbstractContext;
+import org.apache.deltaspike.core.util.context.ContextualStorage;
+
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.ExtendedClientDetails;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.VaadinSession;
 
 import static javax.enterprise.event.Reception.IF_EXISTS;
 
@@ -41,9 +58,9 @@ import static javax.enterprise.event.Reception.IF_EXISTS;
  */
 public class RouteScopedContext extends AbstractContext {
 
-    @NormalUIScoped
+    @VaadinSessionScoped
     public static class ContextualStorageManager
-            extends AbstractContextualStorageManager<Class> {
+            extends AbstractContextualStorageManager<RouteStorageKey> {
 
         public ContextualStorageManager() {
             // Session lock checked in VaadinSessionScopedContext while
@@ -51,19 +68,176 @@ public class RouteScopedContext extends AbstractContext {
             super(false);
         }
 
-        private void onAfterNavigation(@Observes(notifyObserver = IF_EXISTS)
-                                               AfterNavigationEvent event) {
-            Set<Class> activeChain = event.getActiveChain().stream()
-                    .map(Object::getClass)
-                    .collect(Collectors.toSet());
-
-            Set<Class> missingFromChain = getKeySet().stream()
-                    .filter(routeCompClass -> !activeChain.contains(routeCompClass))
-                    .collect(Collectors.toSet());
-
-            missingFromChain.forEach(this::destroy);
+        @Override
+        protected ContextualStorage newContextualStorage(RouteStorageKey key) {
+            UI.getCurrent().addDetachListener(
+                    event -> handleUIDetach(event.getUI(), key));
+            return super.newContextualStorage(key);
         }
 
+        private void onAfterNavigation(
+                @Observes(notifyObserver = IF_EXISTS) AfterNavigationEvent event) {
+            Set<Class<?>> activeChain = event.getActiveChain().stream()
+                    .map(Object::getClass).collect(Collectors.toSet());
+
+            destroyDescopedBeans(event.getLocationChangeEvent().getUI(),
+                    activeChain);
+
+        }
+
+        private void onBeforeEnter(@Observes BeforeEnterEvent event) {
+            UI ui = event.getUI();
+            ComponentUtil.setData(ui, NavigationData.class, new NavigationData(
+                    event.getNavigationTarget(), event.getLayouts()));
+
+            Set<Class<?>> activeChain = new HashSet<>();
+            activeChain.add(event.getNavigationTarget());
+            activeChain.addAll(event.getLayouts());
+
+            destroyDescopedBeans(ui, activeChain);
+        }
+
+        private void destroyDescopedBeans(UI ui,
+                Set<Class<?>> navigationChain) {
+            String uiStoreId = getUIStoreId(ui);
+
+            Set<RouteStorageKey> missingKeys = getKeySet().stream()
+                    .filter(key -> key.getUIId().equals(uiStoreId))
+                    .filter(key -> !navigationChain.contains(key.getOwner()))
+                    .collect(Collectors.toSet());
+
+            File file = new File("/Users/denis/test.log");
+            try {
+                Files.write(file.toPath(),
+                        Arrays.asList("missing keys " + missingKeys,
+                                "keys : " + getKeySet(),
+                                " active chain: " + navigationChain),
+                        StandardOpenOption.APPEND);
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+            missingKeys.forEach(this::destroy);
+        }
+
+        private void handleUIDetach(UI ui, RouteStorageKey key) {
+            UI uiAfterRefresh = findPreservingUI(ui);
+            if (uiAfterRefresh == null) {
+                destroy(key);
+            } else {
+                uiAfterRefresh.addDetachListener(
+                        event -> handleUIDetach(event.getUI(), key));
+            }
+        }
+
+        private UI findPreservingUI(UI ui) {
+            VaadinSession session = ui.getSession();
+            String windowName = getWindowName(ui);
+            for (UI sessionUi : session.getUIs()) {
+                if (sessionUi != ui && windowName != null
+                        && windowName.equals(getWindowName(sessionUi))) {
+                    return sessionUi;
+                }
+            }
+            return null;
+        }
+
+        private static String getWindowName(UI ui) {
+            ExtendedClientDetails details = ui.getInternals()
+                    .getExtendedClientDetails();
+            if (details == null) {
+                return null;
+            }
+            return details.getWindowName();
+        }
+
+        private RouteStorageKey getKey(UI ui, Class<?> owner) {
+            ExtendedClientDetails details = ui.getInternals()
+                    .getExtendedClientDetails();
+            RouteStorageKey key = new RouteStorageKey(owner, getUIStoreId(ui));
+            if (details == null) {
+                ui.getPage().retrieveExtendedClientDetails(
+                        det -> relocate(ui, key));
+            }
+            return key;
+        }
+
+        private void relocate(UI ui, RouteStorageKey key) {
+            relocate(key,
+                    new RouteStorageKey(key.getOwner(), getUIStoreId(ui)));
+        }
+
+        private String getUIStoreId(UI ui) {
+            ExtendedClientDetails details = ui.getInternals()
+                    .getExtendedClientDetails();
+            if (details == null) {
+                return "uid-" + ui.getUIId();
+            } else {
+                return "win-" + getWindowName(ui);
+            }
+        }
+
+    }
+
+    private static class RouteStorageKey implements Serializable {
+        private final Class<?> owner;
+        private final String uiId;
+
+        private RouteStorageKey(Class<?> owner, String uiId) {
+            this.owner = owner;
+            this.uiId = uiId;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof RouteStorageKey)) {
+                return false;
+            }
+            if (obj == this) {
+                return true;
+            }
+            RouteStorageKey key = (RouteStorageKey) obj;
+            return owner.equals(key.owner) && uiId.equals(key.uiId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(owner, uiId);
+        }
+
+        @Override
+        public String toString() {
+            return "[ ui-key='" + getUIId() + "', owner='" + getOwner() + "' ]";
+        }
+
+        Class<?> getOwner() {
+            return owner;
+        }
+
+        String getUIId() {
+            return uiId;
+        }
+
+    }
+
+    static class NavigationData {
+        private final Class<?> navigationTarget;
+        private final List<Class<? extends RouterLayout>> layouts;
+
+        NavigationData(Class<?> navigationTarget,
+                List<Class<? extends RouterLayout>> layouts) {
+            this.navigationTarget = navigationTarget;
+            this.layouts = layouts;
+        }
+
+        Class<?> getNavigationTarget() {
+            return navigationTarget;
+        }
+
+        List<Class<? extends RouterLayout>> getLayouts() {
+            return layouts;
+        }
     }
 
     private ContextualStorageManager contextManager;
@@ -75,9 +249,9 @@ public class RouteScopedContext extends AbstractContext {
     }
 
     public void init(BeanManager beanManager,
-                     Supplier<Boolean> isUIContextActive) {
-        contextManager = BeanProvider
-                .getContextualReference(beanManager, ContextualStorageManager.class, false);
+            Supplier<Boolean> isUIContextActive) {
+        contextManager = BeanProvider.getContextualReference(beanManager,
+                ContextualStorageManager.class, false);
         this.beanManager = beanManager;
         this.isUIContextActive = isUIContextActive;
     }
@@ -94,29 +268,58 @@ public class RouteScopedContext extends AbstractContext {
 
     @Override
     protected ContextualStorage getContextualStorage(Contextual<?> contextual,
-                                                     boolean createIfNotExist) {
-        Class key = convertToKey(contextual);
+            boolean createIfNotExist) {
+        RouteStorageKey key = convertToKey(contextual);
         return contextManager.getContextualStorage(key, createIfNotExist);
     }
 
-    private Class convertToKey(Contextual<?> contextual) {
-        if (!(contextual instanceof Bean)) {
-            if (contextual instanceof PassivationCapable) {
-                final String id = ((PassivationCapable) contextual).getId();
-                contextual = beanManager.getPassivationCapableBean(id);
-            } else {
-                throw new IllegalArgumentException(
-                        contextual.getClass().getName()
-                                + " is not of type " + Bean.class.getName());
-            }
+    private RouteStorageKey convertToKey(Contextual<?> contextual) {
+        Bean<?> bean = getBean(contextual);
+        UI ui = UI.getCurrent();
+        Class<?> owner = getOwner(ui, bean);
+        if (!navigationChainHasOwner(ui, owner)) {
+            throw new IllegalStateException(String.format(
+                    "Route owner '%s' instance is not available in the "
+                            + "active navigation components chain: the scope defined by the bean '%s' doesn't exist.",
+                    owner, bean.getBeanClass()));
         }
-        final Bean<?> bean = (Bean<?>) contextual;
-        return bean.getQualifiers()
-                .stream()
-                .filter(annotation -> annotation instanceof RouteScopeOwner)
-                .map(annotation -> (Class) (((RouteScopeOwner) annotation).value()))
-                .findFirst()
-                .orElse(bean.getBeanClass());
+        return contextManager.getKey(ui, owner);
     }
 
+    private boolean navigationChainHasOwner(UI ui, Class<?> owner) {
+        NavigationData data = ComponentUtil.getData(ui, NavigationData.class);
+        if (owner.equals(data.getNavigationTarget())) {
+            return true;
+        }
+        return data.getLayouts().stream()
+                .anyMatch(clazz -> clazz.equals(owner));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<?> getOwner(UI ui, Bean<?> bean) {
+        return bean.getQualifiers().stream()
+                .filter(annotation -> annotation instanceof RouteScopeOwner)
+                .map(annotation -> (Class<?>) (((RouteScopeOwner) annotation)
+                        .value()))
+                .findFirst().orElseGet(() -> getCurrentNavigationTarget(ui));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Class getCurrentNavigationTarget(UI ui) {
+        NavigationData data = ComponentUtil.getData(ui, NavigationData.class);
+        return data.getNavigationTarget();
+    }
+
+    private Bean<?> getBean(Contextual<?> contextual) {
+        if (contextual instanceof Bean) {
+            return (Bean<?>) contextual;
+        }
+        if (contextual instanceof PassivationCapable) {
+            String id = ((PassivationCapable) contextual).getId();
+            return beanManager.getPassivationCapableBean(id);
+        } else {
+            throw new IllegalArgumentException(contextual.getClass().getName()
+                    + " is not of type " + Bean.class.getName());
+        }
+    }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -16,6 +16,29 @@
 
 package com.vaadin.cdi;
 
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.cdi.DeploymentValidator.BeanInfo;
 import com.vaadin.cdi.DeploymentValidator.DeploymentProblem;
 import com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode;
@@ -31,27 +54,6 @@ import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
-import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.Vetoed;
-import javax.inject.Inject;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NON_ROUTE_SCOPED_HAVE_OWNER;
@@ -88,10 +90,6 @@ public class DeploymentValidatorTest {
     public static class OwnerIsNotRouteComponent {
     }
 
-    @RouteScoped
-    public static class AbsentOwnerOfNonRouteComponent {
-    }
-
     @Route
     @RouteScoped
     @RouteScopeOwner(RouteTargetOfSelf.class)
@@ -108,9 +106,11 @@ public class DeploymentValidatorTest {
     }
 
     @RouteScoped
-    public static class TestHasErrorParameter extends Label implements HasErrorParameter<NullPointerException> {
+    public static class TestHasErrorParameter extends Label
+            implements HasErrorParameter<NullPointerException> {
         @Override
-        public int setErrorParameter(BeforeEnterEvent event, ErrorParameter<NullPointerException> parameter) {
+        public int setErrorParameter(BeforeEnterEvent event,
+                ErrorParameter<NullPointerException> parameter) {
             return 0;
         }
     }
@@ -163,8 +163,8 @@ public class DeploymentValidatorTest {
                 return false;
             }
             ProblemId problemId = (ProblemId) o;
-            return errorCode == problemId.errorCode &&
-                    Objects.equals(baseType, problemId.baseType);
+            return errorCode == problemId.errorCode
+                    && Objects.equals(baseType, problemId.baseType);
         }
 
         @Override
@@ -174,10 +174,8 @@ public class DeploymentValidatorTest {
 
         @Override
         public String toString() {
-            return "ProblemId{" +
-                    "errorCode=" + errorCode +
-                    ", baseType=" + baseType +
-                    '}';
+            return "ProblemId{" + "errorCode=" + errorCode + ", baseType="
+                    + baseType + '}';
         }
     }
 
@@ -201,32 +199,25 @@ public class DeploymentValidatorTest {
 
     @Test
     public void validate_normalScopedProblems_collected() {
-        Set<BeanInfo> infoSet = createBeanSet(
-                PseudoScopedLabel.class,
-                NormalScopedBean.class,
-                NormalScopedLabel.class,
+        Set<BeanInfo> infoSet = createBeanSet(PseudoScopedLabel.class,
+                NormalScopedBean.class, NormalScopedLabel.class,
                 ProducedNormalScopedComponent.class);
 
         validator.validateForTest(infoSet, problems::add);
 
         assertEquals(2, problems.size());
         assertProblemExists(NORMAL_SCOPED_COMPONENT, NormalScopedLabel.class);
-        assertProblemExists(NORMAL_SCOPED_COMPONENT, ProducedNormalScopedComponent.class);
+        assertProblemExists(NORMAL_SCOPED_COMPONENT,
+                ProducedNormalScopedComponent.class);
     }
 
     @Test
     public void validate_routeScopedProblems_collected() {
-        Set<BeanInfo> infoSet = createBeanSet(
-                NonRouteScopedHaveOwner.class,
-                OwnerIsNotRouteComponent.class,
-                AbsentOwnerOfNonRouteComponent.class,
-                RouteTargetOfSelf.class,
-                TestRouteScopedTarget.class,
-                TestRouterLayout.class,
-                TestHasErrorParameter.class,
-                BeanOfHasErrorParameter.class,
-                BeanOfRouterLayout.class,
-                BeanOfRouteTarget.class,
+        Set<BeanInfo> infoSet = createBeanSet(NonRouteScopedHaveOwner.class,
+                OwnerIsNotRouteComponent.class, RouteTargetOfSelf.class,
+                TestRouteScopedTarget.class, TestRouterLayout.class,
+                TestHasErrorParameter.class, BeanOfHasErrorParameter.class,
+                BeanOfRouterLayout.class, BeanOfRouteTarget.class,
                 RouteTargetOfRouterLayout.class,
                 ProducedRouteScopedBeanWithoutOwner.class);
 
@@ -237,8 +228,6 @@ public class DeploymentValidatorTest {
                 OwnerIsNotRouteComponent.class);
         assertProblemExists(NON_ROUTE_SCOPED_HAVE_OWNER,
                 NonRouteScopedHaveOwner.class);
-        assertProblemExists(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
-                AbsentOwnerOfNonRouteComponent.class);
         assertProblemExists(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
                 ProducedRouteScopedBeanWithoutOwner.class);
     }
@@ -255,18 +244,18 @@ public class DeploymentValidatorTest {
 
     private Set<BeanInfo> createBeanSet(Type... clazz) {
         Map<Type, BeanInfo> map = getBeanInfoSetAsMap();
-        return Arrays
-                .stream(clazz)
-                .map(map::get)
-                .collect(Collectors.toSet());
+        return Arrays.stream(clazz).map(map::get).collect(Collectors.toSet());
     }
 
     private Map<Type, BeanInfo> getBeanInfoSetAsMap() {
         return beanInfoSetHolder.getInfoSet().stream()
-                // Weld causes duplicate key because of exposing weird things as Object.
+                // Weld causes duplicate key because of exposing weird things as
+                // Object.
                 // Tests are not interested in it.
-                .filter(beanInfo -> !beanInfo.getBaseType().equals(Object.class))
-                .collect(Collectors.toMap(BeanInfo::getBaseType, Function.identity()));
+                .filter(beanInfo -> !beanInfo.getBaseType()
+                        .equals(Object.class))
+                .collect(Collectors.toMap(BeanInfo::getBaseType,
+                        Function.identity()));
     }
 
     @Produces

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/DeploymentValidatorTest.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.cdi.DeploymentValidator.BeanInfo;
 import com.vaadin.cdi.DeploymentValidator.DeploymentProblem;
 import com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode;
-import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.NormalUIScoped;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
@@ -55,10 +54,7 @@ import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 
-import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.ABSENT_OWNER_OF_NON_ROUTE_COMPONENT;
-import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NON_ROUTE_SCOPED_HAVE_OWNER;
 import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.NORMAL_SCOPED_COMPONENT;
-import static com.vaadin.cdi.DeploymentValidator.DeploymentProblem.ErrorCode.OWNER_IS_NOT_ROUTE_COMPONENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -79,15 +75,6 @@ public class DeploymentValidatorTest {
 
     @Vetoed
     public static class ProducedNormalScopedComponent extends Component {
-    }
-
-    @RouteScopeOwner(RouteTargetOfSelf.class)
-    public static class NonRouteScopedHaveOwner {
-    }
-
-    @RouteScopeOwner(PseudoScopedLabel.class)
-    @RouteScoped
-    public static class OwnerIsNotRouteComponent {
     }
 
     @Route
@@ -134,10 +121,6 @@ public class DeploymentValidatorTest {
     @RouteScopeOwner(TestHasErrorParameter.class)
     @RouteScoped
     public static class BeanOfHasErrorParameter {
-    }
-
-    @Vetoed
-    public static class ProducedRouteScopedBeanWithoutOwner {
     }
 
     private static class ProblemId {
@@ -213,23 +196,15 @@ public class DeploymentValidatorTest {
 
     @Test
     public void validate_routeScopedProblems_collected() {
-        Set<BeanInfo> infoSet = createBeanSet(NonRouteScopedHaveOwner.class,
-                OwnerIsNotRouteComponent.class, RouteTargetOfSelf.class,
+        Set<BeanInfo> infoSet = createBeanSet(RouteTargetOfSelf.class,
                 TestRouteScopedTarget.class, TestRouterLayout.class,
                 TestHasErrorParameter.class, BeanOfHasErrorParameter.class,
                 BeanOfRouterLayout.class, BeanOfRouteTarget.class,
-                RouteTargetOfRouterLayout.class,
-                ProducedRouteScopedBeanWithoutOwner.class);
+                RouteTargetOfRouterLayout.class);
 
         validator.validateForTest(infoSet, problems::add);
 
-        assertEquals(4, problems.size());
-        assertProblemExists(OWNER_IS_NOT_ROUTE_COMPONENT,
-                OwnerIsNotRouteComponent.class);
-        assertProblemExists(NON_ROUTE_SCOPED_HAVE_OWNER,
-                NonRouteScopedHaveOwner.class);
-        assertProblemExists(ABSENT_OWNER_OF_NON_ROUTE_COMPONENT,
-                ProducedRouteScopedBeanWithoutOwner.class);
+        assertEquals(0, problems.size());
     }
 
     private void assertProblemExists(ErrorCode errorCode, Type baseType) {
@@ -262,12 +237,6 @@ public class DeploymentValidatorTest {
     @NormalUIScoped
     private ProducedNormalScopedComponent getProducedComponent() {
         return new ProducedNormalScopedComponent();
-    }
-
-    @Produces
-    @NormalRouteScoped
-    private ProducedRouteScopedBeanWithoutOwner getProducedRouteScopedBeanWithoutOwner() {
-        return new ProducedRouteScopedBeanWithoutOwner();
     }
 
     private static Logger getLogger() {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/AbstractContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/AbstractContextTest.java
@@ -16,14 +16,15 @@
 
 package com.vaadin.cdi.context;
 
+import javax.enterprise.context.ContextNotActiveException;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.enterprise.context.ContextNotActiveException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -97,12 +98,11 @@ public abstract class AbstractContextTest<T extends TestBean> {
 
     protected UnderTestContext createContext() {
         UnderTestContext underTestContext = newContextUnderTest();
-/*
-        UnderTestContext implementations set fields
-        to Vaadin CurrentInstance.
-        Need to hold a hard reference to prevent possible GC,
-        because CurrentInstance works with weak reference.
-*/
+        /*
+         * UnderTestContext implementations set fields to Vaadin
+         * CurrentInstance. Need to hold a hard reference to prevent possible
+         * GC, because CurrentInstance works with weak reference.
+         */
         contexts.add(underTestContext);
         return underTestContext;
     }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextNormalTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextNormalTest.java
@@ -16,14 +16,19 @@
 
 package com.vaadin.cdi.context;
 
-import com.vaadin.cdi.annotation.NormalRouteScoped;
-import com.vaadin.flow.router.Route;
+import java.util.Collections;
+
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.runner.RunWith;
 
+import com.vaadin.cdi.annotation.NormalRouteScoped;
+import com.vaadin.cdi.context.RouteScopedContext.NavigationData;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.router.Route;
+
 @RunWith(CdiTestRunner.class)
-public class RouteContextNormalTest
-        extends AbstractContextTest<RouteContextNormalTest.RouteScopedTestBean> {
+public class RouteContextNormalTest extends
+        AbstractContextTest<RouteContextNormalTest.RouteScopedTestBean> {
 
     @NormalRouteScoped
     @Route("")
@@ -38,7 +43,19 @@ public class RouteContextNormalTest
     @Override
     protected UnderTestContext newContextUnderTest() {
         // Intentionally UI Under Test Context. Nothing else needed.
-        return new UIUnderTestContext();
+        UIUnderTestContext context = new UIUnderTestContext() {
+
+            @Override
+            public void activate() {
+                super.activate();
+
+                NavigationData data = new NavigationData(
+                        TestNavigationTarget.class, Collections.emptyList());
+                ComponentUtil.setData(getUi(), NavigationData.class, data);
+            }
+        };
+
+        return context;
     }
 
     @Override

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextPseudoTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextPseudoTest.java
@@ -16,14 +16,25 @@
 
 package com.vaadin.cdi.context;
 
-import com.vaadin.cdi.annotation.RouteScoped;
-import com.vaadin.flow.router.Route;
+import java.util.Collections;
+
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.runner.RunWith;
 
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.cdi.context.RouteScopedContext.NavigationData;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.router.Route;
+
 @RunWith(CdiTestRunner.class)
-public class RouteContextPseudoTest
-        extends AbstractContextTest<RouteContextPseudoTest.RouteScopedTestBean> {
+public class RouteContextPseudoTest extends
+        AbstractContextTest<RouteContextPseudoTest.RouteScopedTestBean> {
+
+    @Override
+    public void setUp() {
+        // TODO Auto-generated method stub
+        super.setUp();
+    }
 
     @RouteScoped
     @Route("")
@@ -38,7 +49,19 @@ public class RouteContextPseudoTest
     @Override
     protected UnderTestContext newContextUnderTest() {
         // Intentionally UI Under Test Context. Nothing else needed.
-        return new UIUnderTestContext();
+        UIUnderTestContext context = new UIUnderTestContext() {
+
+            @Override
+            public void activate() {
+                super.activate();
+
+                NavigationData data = new NavigationData(
+                        TestNavigationTarget.class, Collections.emptyList());
+                ComponentUtil.setData(getUi(), NavigationData.class, data);
+            }
+        };
+
+        return context;
     }
 
     @Override

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
@@ -16,88 +16,109 @@
 
 package com.vaadin.cdi.context;
 
-import com.vaadin.cdi.annotation.RouteScopeOwner;
-import com.vaadin.cdi.annotation.RouteScoped;
-import com.vaadin.flow.component.HasElement;
-import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.router.AfterNavigationEvent;
-import com.vaadin.flow.router.Route;
+import javax.annotation.PreDestroy;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.Collections;
+
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.cdi.context.RouteScopedContext.NavigationData;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.ExtendedClientDetails;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.LocationChangeEvent;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinSession;
 
 @RunWith(CdiTestRunner.class)
 public class RouteContextualStorageManagerTest {
 
     private static final String STATE = "hello";
 
-    private abstract static class HasElementTestBean extends TestBean implements HasElement {
+    private abstract static class HasElementTestBean extends TestBean
+            implements HasElement {
         @Override
         public Element getElement() {
             return null;
         }
     }
 
-    @RouteScoped
     @Route("group1")
-    public static class Group1 extends HasElementTestBean  {
+    public static class Group1 extends HasElementTestBean {
     }
 
     @RouteScoped
     @RouteScopeOwner(Group1.class)
     public static class MemberOfGroup1 extends HasElementTestBean {
+
+        boolean isDestroyed;
+
+        @PreDestroy
+        private void onDestroy() {
+            isDestroyed = true;
+        }
     }
 
     @RouteScoped
+    public static class NoOwnerBean extends HasElementTestBean {
+
+        boolean isDestroyed;
+
+        @PreDestroy
+        private void onDestroy() {
+            isDestroyed = true;
+        }
+
+    }
+
     @Route("group2")
     public static class Group2 extends HasElementTestBean {
     }
 
-    private UIUnderTestContext uiUnderTestContext;
+    @Route("")
+    public static class InitialRoute extends HasElementTestBean {
 
-    @Inject
-    private Provider<Group1> group1;
+    }
+
+    private UIUnderTestContext uiUnderTestContext;
 
     @Inject
     @RouteScopeOwner(Group1.class)
     private Provider<MemberOfGroup1> memberOfGroup1;
 
     @Inject
-    private Provider<Group2> group2;
+    private Provider<NoOwnerBean> noOwnerBean;
+
+    @Inject
+    private Event<BeforeEnterEvent> beforeNavigationTrigger;
 
     @Inject
     private Event<AfterNavigationEvent> afterNavigationTrigger;
 
-    private List<HasElement> chain;
-    private AfterNavigationEvent event;
+    private BeforeEnterEvent event;
+    private AfterNavigationEvent afterEvent;
+    private LocationChangeEvent changeEvent;
+
+    private NavigationData data = Mockito.mock(NavigationData.class);
 
     @Before
     public void setUp() {
-        uiUnderTestContext = new UIUnderTestContext();
-        uiUnderTestContext.activate();
-
-        group1.get().setState(STATE);
-        group2.get().setState(STATE);
-        memberOfGroup1.get().setState(STATE);
-
-        assertEquals(STATE, group1.get().getState());
-        assertEquals(STATE, memberOfGroup1.get().getState());
-        assertEquals(STATE, group2.get().getState());
-
-        chain = new ArrayList<>();
-        event = Mockito.mock(AfterNavigationEvent.class);
-        Mockito.when(event.getActiveChain()).thenReturn(chain);
+        doSetUp(null, null);
     }
 
     @After
@@ -105,34 +126,159 @@ public class RouteContextualStorageManagerTest {
         uiUnderTestContext.tearDownAll();
     }
 
-    @Test
-    public void onAfterNavigation_chainIsEmpty_allDestroyed() {
-        afterNavigationTrigger.fire(event);
+    @Test(expected = IllegalStateException.class)
+    public void onBeforeEnter_initialNavigationTarget_scopeDoesNotExist_Throws() {
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) InitialRoute.class);
+        beforeNavigationTrigger.fire(event);
 
-        assertEquals("", group1.get().getState());
-        assertEquals("", memberOfGroup1.get().getState());
-        assertEquals("", group2.get().getState());
+        memberOfGroup1.get();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void afterNavigation_initialNavigationTarget_scopeDoesNotExist_Throws() {
+        Mockito.when(afterEvent.getActiveChain())
+                .thenReturn(Collections.singletonList(new InitialRoute()));
+        afterNavigationTrigger.fire(afterEvent);
+
+        memberOfGroup1.get();
     }
 
     @Test
-    public void onAfterNavigation_chainDoesNotContainOwner_ownerDestroyedOtherRemained() {
-        chain.add(group1.get());
-        afterNavigationTrigger.fire(event);
+    public void onBeforeEnter_group1Navigation_beansAreScoped() {
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
 
-        assertEquals(STATE, group1.get().getState());
-        assertEquals(STATE, memberOfGroup1.get().getState());
-        assertEquals("", group2.get().getState());
+        MemberOfGroup1 bean = memberOfGroup1.get();
+        bean.setState(STATE);
+        Assert.assertEquals(STATE, memberOfGroup1.get().getState());
+
+        noOwnerBean.get().setState(STATE);
+        Assert.assertEquals(STATE, noOwnerBean.get().getState());
     }
 
     @Test
-    public void onAfterNavigation_chainDoesNotContainOwnerForAssigned_bothDestroyedOtherRemained() {
-        chain.add(group2.get());
-        chain.add(memberOfGroup1.get());
-        afterNavigationTrigger.fire(event);
+    public void onBeforeEnter_group2NavigationAfterGroup1_beansAreDestroyed() {
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
 
-        assertEquals("", group1.get().getState());
-        assertEquals("", memberOfGroup1.get().getState());
-        assertEquals(STATE, group2.get().getState());
+        MemberOfGroup1 bean1 = memberOfGroup1.get();
+        bean1.setState(STATE);
+        NoOwnerBean bean2 = noOwnerBean.get();
+        bean2.setState(STATE);
+
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group2.class);
+        beforeNavigationTrigger.fire(event);
+
+        Assert.assertTrue(bean1.isDestroyed);
+        Assert.assertTrue(bean2.isDestroyed);
+
+        // no owner bean is not preserved: the new one is created
+        Assert.assertNotEquals(STATE, noOwnerBean.get().getState());
     }
 
+    @Test
+    public void afterNavigation_group2NavigationAftergroup1_beansAreDestroyed() {
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean1 = memberOfGroup1.get();
+        bean1.setState(STATE);
+        NoOwnerBean bean2 = noOwnerBean.get();
+        bean2.setState(STATE);
+
+        Mockito.when(afterEvent.getActiveChain())
+                .thenReturn(Collections.singletonList(new Group2()));
+        afterNavigationTrigger.fire(afterEvent);
+
+        Assert.assertTrue(bean1.isDestroyed);
+        Assert.assertTrue(bean2.isDestroyed);
+    }
+
+    @Test
+    public void preserveOnRefresh_anotherUIHasSameWindowName_beanIsPreserved() {
+        UI ui = doSetUp("foo", null);
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean1 = memberOfGroup1.get();
+        bean1.setState(STATE);
+
+        // set another UI instance with the same window name into the context
+        doSetUp("foo", ui.getSession());
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        ComponentUtil.onComponentDetach(ui);
+
+        Assert.assertFalse(bean1.isDestroyed);
+        Assert.assertEquals(STATE, memberOfGroup1.get().getState());
+    }
+
+    @Test
+    public void onBeforeEnter_anotherUIHasNoWindowName_beanIsDestroyedOnUiDestroy() {
+        UI ui = doSetUp("foo", null);
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean1 = memberOfGroup1.get();
+        bean1.setState(STATE);
+
+        // set another UI instance with the same window name into the context
+        doSetUp(null, ui.getSession());
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        ComponentUtil.onComponentDetach(ui);
+
+        Assert.assertTrue(bean1.isDestroyed);
+        Assert.assertNotEquals(STATE, memberOfGroup1.get().getState());
+    }
+
+    private UI doSetUp(String windowName, VaadinSession session) {
+        changeEvent = Mockito.mock(LocationChangeEvent.class);
+
+        Mockito.when(data.getNavigationTarget())
+                .thenReturn((Class) InitialRoute.class);
+        event = Mockito.mock(BeforeEnterEvent.class);
+        uiUnderTestContext = new UIUnderTestContext(session) {
+
+            @Override
+            public void activate() {
+                super.activate();
+
+                if (windowName != null) {
+                    ExtendedClientDetails details = Mockito
+                            .mock(ExtendedClientDetails.class);
+                    Mockito.when(details.getWindowName())
+                            .thenReturn(windowName);
+                    getUi().getInternals().setExtendedClientDetails(details);
+                }
+
+                ComponentUtil.setData(getUi(), NavigationData.class, data);
+                Mockito.when(changeEvent.getUI()).thenReturn(getUi());
+                Mockito.when(event.getUI())
+                        .thenReturn(uiUnderTestContext.getUi());
+            }
+        };
+        uiUnderTestContext.activate();
+
+        UI ui = uiUnderTestContext.getUi();
+
+        uiUnderTestContext.getUi().getSession().addUI(ui);
+
+        afterEvent = Mockito.mock(AfterNavigationEvent.class);
+        Mockito.when(afterEvent.getLocationChangeEvent())
+                .thenReturn(changeEvent);
+
+        return uiUnderTestContext.getUi();
+    }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionUnderTestContext.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionUnderTestContext.java
@@ -56,6 +56,9 @@ public class SessionUnderTestContext implements UnderTestContext {
         when(session.getConfiguration()).thenReturn(configuration);
         Properties props = new Properties();
         when(configuration.getInitParameters()).thenReturn(props);
+
+        doCallRealMethod().when(session).addUI(Mockito.any());
+        doCallRealMethod().when(session).getUIs();
     }
 
     @Override

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/TestNavigationTarget.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/TestNavigationTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2018 Vaadin Ltd.
+ * Copyright 2000-2021 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,24 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.cdi.context;
 
-package com.vaadin.cdi.itest.routecontext;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 
-import com.vaadin.cdi.annotation.RouteScoped;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
-import com.vaadin.flow.router.Route;
-
-@RouteScoped
-@Route("error")
-public class ErrorView extends AbstractCountedView
-        implements BeforeEnterObserver {
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        if (true) {
-            throw new CustomException();
-        }
-    }
+@Tag(Tag.A)
+class TestNavigationTarget extends Component {
 
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
@@ -27,6 +27,13 @@ public class UIUnderTestContext implements UnderTestContext {
     private static int uiIdNdx = 0;
     private static SessionUnderTestContext sessionContextUnderTest;
 
+    protected UIUnderTestContext() {
+        this(null);
+    }
+
+    protected UIUnderTestContext(VaadinSession session) {
+        this.session = session;
+    }
 
     private void mockUI() {
         if (session == null) {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/UIUnderTestContext.java
@@ -27,7 +27,7 @@ public class UIUnderTestContext implements UnderTestContext {
     private static int uiIdNdx = 0;
     private static SessionUnderTestContext sessionContextUnderTest;
 
-    protected UIUnderTestContext() {
+    public UIUnderTestContext() {
         this(null);
     }
 


### PR DESCRIPTION
- presere beans for PreserveOnRefresh views
- reimplement absent RouteScopeOwner semantic
- do not allow to use (route) scope when it's not available

fixes #369

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
