### PR TITLE
chore: downgrade version to 13.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>vaadin-cdi-parent</artifactId>
-    <version>14.0-SNAPSHOT</version>
+    <version>13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>vaadin-cdi-parent</name>

--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cdi-parent</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>13.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cdi-parent</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-cdi</artifactId>


### PR DESCRIPTION
13.0 will be used to build on top of Flow 8.0 and target Vaadin 21.
Version 12.0 is compatible for Vaadin 15-20.