### PR TITLE
fix: throw on not existing scope only if bean creation is requested

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -264,11 +265,6 @@ public class RouteScopedContext extends AbstractContext {
     @Override
     protected ContextualStorage getContextualStorage(Contextual<?> contextual,
                                                      boolean createIfNotExist) {
-        RouteStorageKey key = convertToKey(contextual, createIfNotExist);
-        return contextManager.getContextualStorage(key, createIfNotExist);
-    }
-
-    private RouteStorageKey convertToKey(Contextual<?> contextual, boolean createIfNotExist) {
         Bean<?> bean = getBean(contextual);
         UI ui = UI.getCurrent();
         Class<?> owner = getOwner(ui, bean);
@@ -278,7 +274,8 @@ public class RouteScopedContext extends AbstractContext {
                             + "active navigation components chain: the scope defined by the bean '%s' doesn't exist.",
                     owner, bean.getBeanClass().getName()));
         }
-        return contextManager.getKey(ui, owner);
+        RouteStorageKey key = contextManager.getKey(ui, owner);
+        return contextManager.getContextualStorage(key, createIfNotExist);
     }
 
     private boolean navigationChainHasOwner(UI ui, Class<?> owner) {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -93,7 +93,7 @@ public class RouteScopedContext extends AbstractContext {
         }
 
         private void destroyDescopedBeans(UI ui,
-                Set<Class<?>> navigationChain) {
+                                          Set<Class<?>> navigationChain) {
             String uiStoreId = getUIStoreId(ui);
 
             Set<RouteStorageKey> missingKeys = getKeySet().stream()
@@ -153,7 +153,7 @@ public class RouteScopedContext extends AbstractContext {
 
         private List<ContextualStorage> getActiveContextualStorages() {
             return getKeySet().stream().filter(
-                    key -> key.getUIId().equals(getUIStoreId(UI.getCurrent())))
+                            key -> key.getUIId().equals(getUIStoreId(UI.getCurrent())))
                     .map(key -> getContextualStorage(key, false))
                     .collect(Collectors.toList());
         }
@@ -216,7 +216,7 @@ public class RouteScopedContext extends AbstractContext {
         private final List<Class<? extends RouterLayout>> layouts;
 
         NavigationData(Class<?> navigationTarget,
-                List<Class<? extends RouterLayout>> layouts) {
+                       List<Class<? extends RouterLayout>> layouts) {
             this.navigationTarget = navigationTarget;
             this.layouts = layouts;
         }
@@ -239,7 +239,7 @@ public class RouteScopedContext extends AbstractContext {
     }
 
     public void init(BeanManager beanManager,
-            Supplier<Boolean> isUIContextActive) {
+                     Supplier<Boolean> isUIContextActive) {
         contextManager = BeanProvider.getContextualReference(beanManager,
                 ContextualStorageManager.class, false);
         this.beanManager = beanManager;
@@ -263,16 +263,16 @@ public class RouteScopedContext extends AbstractContext {
 
     @Override
     protected ContextualStorage getContextualStorage(Contextual<?> contextual,
-            boolean createIfNotExist) {
-        RouteStorageKey key = convertToKey(contextual);
+                                                     boolean createIfNotExist) {
+        RouteStorageKey key = convertToKey(contextual, createIfNotExist);
         return contextManager.getContextualStorage(key, createIfNotExist);
     }
 
-    private RouteStorageKey convertToKey(Contextual<?> contextual) {
+    private RouteStorageKey convertToKey(Contextual<?> contextual, boolean createIfNotExist) {
         Bean<?> bean = getBean(contextual);
         UI ui = UI.getCurrent();
         Class<?> owner = getOwner(ui, bean);
-        if (!navigationChainHasOwner(ui, owner)) {
+        if (!navigationChainHasOwner(ui, owner) && createIfNotExist) {
             throw new IllegalStateException(String.format(
                     "Route owner '%s' instance is not available in the "
                             + "active navigation components chain: the scope defined by the bean '%s' doesn't exist.",


### PR DESCRIPTION
## Description

If bean creation is not requested, just return a null value from context storage
instead of throwing an exception because route owner instance is not available
in current navigation components chain

Fixes #390

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
