### PR TITLE
feat: Retain routescoped parentlayouts on route change

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
@@ -42,7 +42,6 @@ public class EventObserverLayout extends Div implements RouterLayout {
     }
 
     public void onEvent(@Observes(notifyObserver = Reception.IF_EXISTS) CustomEvent event) {
-        System.out.println("================================================= OK ");
         receivedEvents.setText("EVENTS COUNT: " + ++counter);
         add(new Span("EVENT AT " + LocalDateTime.now()));
     }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import java.time.LocalDateTime;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Reception;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.RouterLayout;
+
+@RouteScoped
+@CdiComponent
+public class EventObserverLayout extends Div implements RouterLayout {
+
+    public static final String EVENTS_COUNTER_LABEL = "eventsCounter";
+    private final Label receivedEvents;
+    private int counter = 0;
+
+    public EventObserverLayout() {
+        receivedEvents = new Label();
+        receivedEvents.setId(EVENTS_COUNTER_LABEL);
+        add(receivedEvents);
+    }
+
+    public void onEvent(@Observes(notifyObserver = Reception.IF_EXISTS) CustomEvent event) {
+        System.out.println("================================================= OK ");
+        receivedEvents.setText("EVENTS COUNT: " + ++counter);
+        add(new Span("EVENT AT " + LocalDateTime.now()));
+    }
+
+
+    public enum CustomEvent {
+        INSTANCE
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "layout-event", layout = EventObserverLayout.class)
+@RouteScoped
+
+public class LayoutEventView extends Div {
+
+    public static final String FIRE = "FIRE";
+    public static final String CHANGE_VIEW = "CHANGE_VIEW";
+    public static final String VIEW_NAME = "VIEW_NAME";
+    @Inject
+    private Event<EventObserverLayout.CustomEvent> eventTrigger;
+
+    @PostConstruct
+    private void init() {
+        NativeButton fireBtn = new NativeButton("fire event", clickEvent
+                -> eventTrigger.fire(EventObserverLayout.CustomEvent.INSTANCE));
+        fireBtn.setId(FIRE);
+        NativeButton navigateBtn = new NativeButton("change view", clickEvent
+                -> UI.getCurrent().navigate(LayoutEventView2.class));
+        navigateBtn.setId(CHANGE_VIEW);
+
+        Span viewName = new Span("Layout Event View 1");
+        viewName.setId(VIEW_NAME);
+        add(viewName, fireBtn, navigateBtn);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.router.Route;
 
 @Route(value = "layout-event", layout = EventObserverLayout.class)
 @RouteScoped
-
 public class LayoutEventView extends Div {
 
     public static final String FIRE = "FIRE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "layout-event-2", layout = EventObserverLayout.class)
+@RouteScoped
+
+public class LayoutEventView2 extends Div {
+
+    public static final String FIRE = "FIRE";
+    public static final String CHANGE_VIEW = "CHANGE_VIEW";
+    public static final String VIEW_NAME = "VIEW_NAME";
+    @Inject
+    private Event<EventObserverLayout.CustomEvent> eventTrigger;
+
+    @PostConstruct
+    private void init() {
+        NativeButton fireBtn = new NativeButton("fire event", clickEvent
+                -> eventTrigger.fire(EventObserverLayout.CustomEvent.INSTANCE));
+        fireBtn.setId(FIRE);
+        NativeButton navigateBtn = new NativeButton("change view", clickEvent
+                -> UI.getCurrent().navigate(LayoutEventView.class));
+        navigateBtn.setId(CHANGE_VIEW);
+        Span viewName = new Span("Layout Event View 2");
+        viewName.setId(VIEW_NAME);
+        add(viewName, fireBtn, navigateBtn);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.router.Route;
 
 @Route(value = "layout-event-2", layout = EventObserverLayout.class)
 @RouteScoped
-
 public class LayoutEventView2 extends Div {
 
     public static final String FIRE = "FIRE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
@@ -32,6 +32,7 @@ public class RootView extends AbstractCountedView {
     public static final String REROUTE = "reroute";
     public static final String POSTPONE = "postpone";
     public static final String EVENT = "event";
+    public static final String LAYOUT_EVENT = "layout-event";
     public static final String ERROR = "ERROR";
 
     @PostConstruct
@@ -41,6 +42,7 @@ public class RootView extends AbstractCountedView {
                 new Div(new RouterLink(REROUTE, RerouteView.class)),
                 new Div(new RouterLink(POSTPONE, PostponeView.class)),
                 new Div(new RouterLink(EVENT, EventView.class)),
+                new Div(new RouterLink(LAYOUT_EVENT, LayoutEventView.class)),
                 new Div(new RouterLink(ERROR, ErrorView.class)));
     }
 

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
@@ -36,7 +36,10 @@ import com.vaadin.cdi.itest.routecontext.DetailAssignedView;
 import com.vaadin.cdi.itest.routecontext.ErrorHandlerView;
 import com.vaadin.cdi.itest.routecontext.ErrorParentView;
 import com.vaadin.cdi.itest.routecontext.ErrorView;
+import com.vaadin.cdi.itest.routecontext.EventObserverLayout;
 import com.vaadin.cdi.itest.routecontext.EventView;
+import com.vaadin.cdi.itest.routecontext.LayoutEventView;
+import com.vaadin.cdi.itest.routecontext.LayoutEventView2;
 import com.vaadin.cdi.itest.routecontext.MainLayout;
 import com.vaadin.cdi.itest.routecontext.MasterView;
 import com.vaadin.cdi.itest.routecontext.PostponeView;
@@ -156,6 +159,27 @@ public class RouteContextTest extends AbstractCdiTest {
 
         click(EventView.FIRE);
         assertTextEquals("HELLO", EventView.OBSERVER_LABEL);
+    }
+
+    @Test
+    public void eventObservedByLayout() {
+        follow(RootView.LAYOUT_EVENT);
+        assertTextEquals("", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView.FIRE);
+        assertTextEquals("EVENTS COUNT: 1", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView.CHANGE_VIEW);
+        assertTextEquals("Layout Event View 2", LayoutEventView2.VIEW_NAME);
+
+        click(LayoutEventView2.FIRE);
+        assertTextEquals("EVENTS COUNT: 2", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView2.CHANGE_VIEW);
+        assertTextEquals("Layout Event View 1", LayoutEventView.VIEW_NAME);
+
+        click(LayoutEventView.FIRE);
+        assertTextEquals("EVENTS COUNT: 3", EventObserverLayout.EVENTS_COUNTER_LABEL);
     }
 
     @Test

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -305,6 +305,8 @@ public class RouteScopedContext extends AbstractContext {
                             + "so bean '%s' has no scope and may not be injected",
                     bean.getBeanClass().getName()));
         }
+        if( data.getLayouts( ).contains( bean.getBeanClass( ) ) )
+            return bean.getBeanClass( );
         return data.getNavigationTarget();
     }
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -31,13 +30,13 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.PassivationCapable;
-import com.vaadin.cdi.util.BeanProvider;
-import com.vaadin.cdi.util.AbstractContext;
-import com.vaadin.cdi.util.ContextualStorage;
 
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.cdi.util.AbstractContext;
+import com.vaadin.cdi.util.BeanProvider;
+import com.vaadin.cdi.util.ContextualStorage;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
@@ -305,8 +304,8 @@ public class RouteScopedContext extends AbstractContext {
                             + "so bean '%s' has no scope and may not be injected",
                     bean.getBeanClass().getName()));
         }
-        if( data.getLayouts( ).contains( bean.getBeanClass( ) ) )
-            return bean.getBeanClass( );
+        if (data.getLayouts().contains(bean.getBeanClass()))
+            return bean.getBeanClass();
         return data.getNavigationTarget();
     }
 


### PR DESCRIPTION
## Description

When changing routes where a RouterLayout comes into play that has a RoutePrefix associated with it and where this routerlayout is annotated to be @RouteScoped the spec has changed between Vaadin CDI 12 and Vaadin CDI 13 so that strictly the @RouteScopeOwner is considered to be the innermost Route component. This broke our code where we were depending on the fact that these RouterLayouts would not be recreated. We had defined services which were RouteScoped and had a RouterLayout as RouteScopeOwner but this did not work anymore.

This proposed change will result in RouterLayouts of this kind to be considered to have themselves as  @RouteScopeOwner. This fits with the notion that the Route part which pertains to this RouterLayout does in fact not change.

So imagine a component A with Route "a" which has a RouterLayout component PARENT with routeprefix "parent". And a second component B which has the same parent, but its route is "b".

So in Vaadin CDI 12.0.0 navigation to /parent/a would instantiate PARENT and A and subsequently navigating to /parent/b would discard A and instantiate B. It would retain PARENT.

In Vaadin CDI 13.0.0 this did not work anymore. Instead navigation to /parent/a would still instantiate PARENT and A, but subsequently navigating to /parent/b would discard PARENT and B and instantiate PARENT and B again.

Fixes #388 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
I did not get integration tests working at all on my windows machine. Using the internal Ubuntu installed in Windows it also failed. So I was not able to run any testing

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
