### PR TITLE
fix: set load-on-startup for automatically registered Vaadin servlet

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiServletDeployer.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiServletDeployer.java
@@ -86,6 +86,7 @@ public class CdiServletDeployer implements ServletContainerInitializer {
 
         registration.setAsyncSupported(true);
         registration.addMapping("/*");
+        registration.setLoadOnStartup(1);
     }
 
     private static ServletRegistration findRootServlet(ServletContext context) {


### PR DESCRIPTION
## Description

When using Vite, DevModeInitializer blocks dev-server startup until a VaadinServlet is deployed because it needs to get the servlet path to use. If the container lazily loads servlets, Vite will not start until the first HTTP request for the Vaadin servlet is received.
This change sets load-on-startup feature for automatically deployed Vaadin servlet, to ensure that the servlet and Vite are loaded on the startup of the Web application

Part of vaadin/flow#14479

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
