### PR TITLE
test: Fixes CdiVaadinServletTest, broken due to missing servlet registration (#420)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <driver.binary.downloader.maven.plugin.version>1.0.18</driver.binary.downloader.maven.plugin.version>
 
-        <vaadin.flow.version>23.0-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>23.3-SNAPSHOT</vaadin.flow.version>
         <slf4j.version>1.7.32</slf4j.version>
         <deltaspike.version>1.9.5</deltaspike.version>
         <owb.version>2.0.25</owb.version>

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletTest.java
@@ -21,8 +21,10 @@ import javax.inject.Inject;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
@@ -96,6 +98,16 @@ public class CdiVaadinServletTest {
         Mockito.when(servletConfig.getServletName()).thenReturn("test");
         Mockito.when(servletContext.getInitParameterNames())
                 .thenReturn(Collections.emptyEnumeration());
+
+        final ServletRegistration servletRegistration
+                = Mockito.mock(ServletRegistration.class);
+        final Map servletRegistrationMap
+                = Collections.singletonMap("test", servletRegistration);
+        Mockito.when(servletContext.getServletRegistrations())
+                .thenReturn(servletRegistrationMap);
+        Mockito.when(servletRegistration.getMappings())
+                .thenReturn(Collections.emptyList());
+
         servlet = new CdiVaadinServlet();
         BeanProvider.injectFields(servlet);
         servlet.init(servletConfig);


### PR DESCRIPTION
Fixes CdíVaadinServletTest which broke due to vaadin/flow#15188 which assumes that vaadin servlet has been registered when Atmosphere is being initialized

(cherry picked from commit 7c29686a4b3e29b78b3af7293887155286e9971d)
