### PR TITLE
feat: Retain routescoped parentlayouts on route change (#394) (CP: 14.1)

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventObserverLayout.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import java.time.LocalDateTime;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.Reception;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.RouterLayout;
+
+@RouteScoped
+@CdiComponent
+public class EventObserverLayout extends Div implements RouterLayout {
+
+    public static final String EVENTS_COUNTER_LABEL = "eventsCounter";
+    private final Label receivedEvents;
+    private int counter = 0;
+
+    public EventObserverLayout() {
+        receivedEvents = new Label();
+        receivedEvents.setId(EVENTS_COUNTER_LABEL);
+        add(receivedEvents);
+    }
+
+    public void onEvent(@Observes(notifyObserver = Reception.IF_EXISTS) CustomEvent event) {
+        receivedEvents.setText("EVENTS COUNT: " + ++counter);
+        add(new Span("EVENT AT " + LocalDateTime.now()));
+    }
+
+
+    public enum CustomEvent {
+        INSTANCE
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "layout-event", layout = EventObserverLayout.class)
+@RouteScoped
+public class LayoutEventView extends Div {
+
+    public static final String FIRE = "FIRE";
+    public static final String CHANGE_VIEW = "CHANGE_VIEW";
+    public static final String VIEW_NAME = "VIEW_NAME";
+    @Inject
+    private Event<EventObserverLayout.CustomEvent> eventTrigger;
+
+    @PostConstruct
+    private void init() {
+        NativeButton fireBtn = new NativeButton("fire event", clickEvent
+                -> eventTrigger.fire(EventObserverLayout.CustomEvent.INSTANCE));
+        fireBtn.setId(FIRE);
+        NativeButton navigateBtn = new NativeButton("change view", clickEvent
+                -> UI.getCurrent().navigate(LayoutEventView2.class));
+        navigateBtn.setId(CHANGE_VIEW);
+
+        Span viewName = new Span("Layout Event View 1");
+        viewName.setId(VIEW_NAME);
+        add(viewName, fireBtn, navigateBtn);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.vaadin.cdi.annotation.RouteScoped;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "layout-event-2", layout = EventObserverLayout.class)
+@RouteScoped
+public class LayoutEventView2 extends Div {
+
+    public static final String FIRE = "FIRE";
+    public static final String CHANGE_VIEW = "CHANGE_VIEW";
+    public static final String VIEW_NAME = "VIEW_NAME";
+    @Inject
+    private Event<EventObserverLayout.CustomEvent> eventTrigger;
+
+    @PostConstruct
+    private void init() {
+        NativeButton fireBtn = new NativeButton("fire event", clickEvent
+                -> eventTrigger.fire(EventObserverLayout.CustomEvent.INSTANCE));
+        fireBtn.setId(FIRE);
+        NativeButton navigateBtn = new NativeButton("change view", clickEvent
+                -> UI.getCurrent().navigate(LayoutEventView.class));
+        navigateBtn.setId(CHANGE_VIEW);
+        Span viewName = new Span("Layout Event View 2");
+        viewName.setId(VIEW_NAME);
+        add(viewName, fireBtn, navigateBtn);
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
@@ -32,6 +32,7 @@ public class RootView extends AbstractCountedView {
     public static final String REROUTE = "reroute";
     public static final String POSTPONE = "postpone";
     public static final String EVENT = "event";
+    public static final String LAYOUT_EVENT = "layout-event";
     public static final String ERROR = "ERROR";
 
     @PostConstruct
@@ -41,6 +42,7 @@ public class RootView extends AbstractCountedView {
                 new Div(new RouterLink(REROUTE, RerouteView.class)),
                 new Div(new RouterLink(POSTPONE, PostponeView.class)),
                 new Div(new RouterLink(EVENT, EventView.class)),
+                new Div(new RouterLink(LAYOUT_EVENT, LayoutEventView.class)),
                 new Div(new RouterLink(ERROR, ErrorView.class)));
     }
 

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
@@ -36,7 +36,10 @@ import com.vaadin.cdi.itest.routecontext.DetailAssignedView;
 import com.vaadin.cdi.itest.routecontext.ErrorHandlerView;
 import com.vaadin.cdi.itest.routecontext.ErrorParentView;
 import com.vaadin.cdi.itest.routecontext.ErrorView;
+import com.vaadin.cdi.itest.routecontext.EventObserverLayout;
 import com.vaadin.cdi.itest.routecontext.EventView;
+import com.vaadin.cdi.itest.routecontext.LayoutEventView;
+import com.vaadin.cdi.itest.routecontext.LayoutEventView2;
 import com.vaadin.cdi.itest.routecontext.MainLayout;
 import com.vaadin.cdi.itest.routecontext.MasterView;
 import com.vaadin.cdi.itest.routecontext.PostponeView;
@@ -156,6 +159,27 @@ public class RouteContextTest extends AbstractCdiTest {
 
         click(EventView.FIRE);
         assertTextEquals("HELLO", EventView.OBSERVER_LABEL);
+    }
+
+    @Test
+    public void eventObservedByLayout() {
+        follow(RootView.LAYOUT_EVENT);
+        assertTextEquals("", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView.FIRE);
+        assertTextEquals("EVENTS COUNT: 1", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView.CHANGE_VIEW);
+        assertTextEquals("Layout Event View 2", LayoutEventView2.VIEW_NAME);
+
+        click(LayoutEventView2.FIRE);
+        assertTextEquals("EVENTS COUNT: 2", EventObserverLayout.EVENTS_COUNTER_LABEL);
+
+        click(LayoutEventView2.CHANGE_VIEW);
+        assertTextEquals("Layout Event View 1", LayoutEventView.VIEW_NAME);
+
+        click(LayoutEventView.FIRE);
+        assertTextEquals("EVENTS COUNT: 3", EventObserverLayout.EVENTS_COUNTER_LABEL);
     }
 
     @Test

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -27,7 +27,6 @@ import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -306,6 +305,8 @@ public class RouteScopedContext extends AbstractContext {
                             + "so bean '%s' has no scope and may not be injected",
                     bean.getBeanClass().getName()));
         }
+        if (data.getLayouts().contains(bean.getBeanClass()))
+            return bean.getBeanClass();
         return data.getNavigationTarget();
     }
 


### PR DESCRIPTION
When changing routes where a RouterLayout comes into play that has a RoutePrefix associated with it and where this routerlayout is annotated to be @RouteScoped the spec has changed between Vaadin CDI 12 and Vaadin CDI 13 so that strictly the RouteScopeOwner is considered to be the innermost Route component.

This change will result in RouterLayouts of this kind to have a RouteScopeOwner which will be themselves. This fits with the notion that the Route part which pertains to this RouterLayout does in fact not change.
