### PR TITLE
refactor!: Instantiator.init() replaced with InstantiatorFactory

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorAlternative.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorAlternative.java
@@ -18,29 +18,14 @@ package com.vaadin.cdi.itest.instantiatorcustomize;
 
 import java.util.stream.Stream;
 
-import jakarta.annotation.Priority;
-import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.spi.Unmanaged;
-import jakarta.interceptor.Interceptor;
 
-import com.vaadin.cdi.annotation.VaadinServiceEnabled;
-import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
-@Priority(Interceptor.Priority.APPLICATION)
-@Alternative
-@VaadinServiceEnabled
-@VaadinServiceScoped
 public class InstantiatorAlternative implements Instantiator {
-
-    @Override
-    public boolean init(VaadinService service) {
-        return true;
-    }
 
     @Override
     public Stream<VaadinServiceInitListener> getServiceInitListeners() {

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorFactoryAlternative.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorFactoryAlternative.java
@@ -17,36 +17,23 @@
 package com.vaadin.cdi.itest.instantiatorcustomize;
 
 import jakarta.annotation.Priority;
-import jakarta.decorator.Decorator;
-import jakarta.decorator.Delegate;
-import jakarta.inject.Inject;
+import jakarta.enterprise.inject.Alternative;
 import jakarta.interceptor.Interceptor;
 
 import com.vaadin.cdi.annotation.VaadinServiceEnabled;
-import com.vaadin.flow.component.HasElement;
+import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.router.NavigationEvent;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
 
 @Priority(Interceptor.Priority.APPLICATION)
-@Decorator
-public abstract class InstantiatorDecorator implements Instantiator {
-    @Inject
-    @Delegate
-    @VaadinServiceEnabled
-    private Instantiator delegate;
+@Alternative
+@VaadinServiceEnabled
+@VaadinServiceScoped
+public class InstantiatorFactoryAlternative implements InstantiatorFactory {
 
     @Override
-    public <T> T getOrCreate(Class<T> type) {
-        T instance = delegate.getOrCreate(type);
-        if (InstantiatorCustomizeView.class.equals(type)) {
-            ((InstantiatorCustomizeView) instance).customize();
-        }
-        return instance;
-    }
-
-    @Override
-    public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType, NavigationEvent event) {
-        // Need to override it too to make it work on both Weld and OWB.
-        return getOrCreate(routeTargetType);
+    public Instantiator createInstantitor(VaadinService service) {
+        return new InstantiatorAlternative();
     }
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorFactoryDecorator.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorFactoryDecorator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.instantiatorcustomize;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
+
+import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
+
+@Priority(Interceptor.Priority.APPLICATION)
+@Decorator
+public abstract class InstantiatorFactoryDecorator implements InstantiatorFactory {
+    @Inject
+    @Delegate
+    @VaadinServiceEnabled
+    private InstantiatorFactory delegate;
+
+    @Override
+    public Instantiator createInstantitor(VaadinService service) {
+        return new InstantiatorAlternative();
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InstantiatorFactoryCustomizeTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InstantiatorFactoryCustomizeTest.java
@@ -18,8 +18,9 @@ package com.vaadin.cdi.itest;
 
 
 import com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorAlternative;
+import com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorFactoryAlternative;
 import com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorCustomizeView;
-import com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorDecorator;
+import com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorFactoryDecorator;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -31,12 +32,13 @@ import static com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorCustomizeVi
 import static com.vaadin.cdi.itest.instantiatorcustomize.InstantiatorCustomizeView.VIEW;
 
 @SuppressWarnings("ArquillianTooManyDeployment")
-public class InstantiatorCustomizeTest extends AbstractCdiTest {
+public class InstantiatorFactoryCustomizeTest extends AbstractCdiTest {
 
     @Deployment(name = "decorator", testable = false)
     public static WebArchive decoratorDeployment() {
         return ArchiveProvider.createWebArchive("instantiator-decorator-test",
-                InstantiatorDecorator.class,
+                InstantiatorAlternative.class,
+                InstantiatorFactoryDecorator.class,
                 InstantiatorCustomizeView.class);
     }
 
@@ -44,6 +46,7 @@ public class InstantiatorCustomizeTest extends AbstractCdiTest {
     public static WebArchive alternativeDeployment() {
         return ArchiveProvider.createWebArchive("instantiator-alternative-test",
                 InstantiatorAlternative.class,
+                InstantiatorFactoryAlternative.class,
                 InstantiatorCustomizeView.class);
     }
 

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/InvalidDeploymentTest.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.cdi.itest;
 
-import com.vaadin.cdi.itest.invaliddeployment.DeploymentView;
-import com.vaadin.cdi.itest.invaliddeployment.NormalScopedLabel;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -26,6 +24,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.vaadin.cdi.itest.invaliddeployment.DeploymentView;
+import com.vaadin.cdi.itest.invaliddeployment.NormalScopedLabel;
 
 @RunWith(Arquillian.class)
 @RunAsClient

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiInstantiator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiInstantiator.java
@@ -18,37 +18,38 @@ package com.vaadin.cdi;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Unmanaged;
-import jakarta.inject.Inject;
 
-import com.vaadin.cdi.annotation.VaadinServiceEnabled;
-import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.VaadinService;
 
 /**
  * Default CDI instantiator.
- * <p>
- * Can be overridden by a @{@link VaadinServiceEnabled} CDI
- * Alternative/Specializes, or can be customized with a Decorator.
  *
  * @see Instantiator
  */
-@VaadinServiceScoped
-@VaadinServiceEnabled
 public class CdiInstantiator extends AbstractCdiInstantiator {
 
-    @Inject
-    private BeanManager beanManager;
+    private final BeanManager beanManager;
+
+    private final DefaultInstantiator delegate;
+
+    public CdiInstantiator(BeanManager beanManager, VaadinService service) {
+        this.beanManager = beanManager;
+        this.delegate = new DefaultInstantiator(service);
+        UsageStatistics.markAsUsed("flow/CdiInstantiator", null);
+    }
+
+    @Override
+    protected DefaultInstantiator getDelegate() {
+        return delegate;
+    }
 
     @Override
     public BeanManager getBeanManager() {
         return beanManager;
-    }
-
-    @Override
-    public Class<? extends VaadinService> getServiceClass() {
-        return CdiVaadinServletService.class;
     }
 
     @Override

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiInstantiatorFactory.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/CdiInstantiatorFactory.java
@@ -1,0 +1,40 @@
+package com.vaadin.cdi;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+
+import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+import com.vaadin.cdi.annotation.VaadinServiceScoped;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Default CDI instantiator factory.
+ * <p>
+ * Can be overridden by a @{@link VaadinServiceEnabled} CDI
+ * Alternative/Specializes, or can be customized with a Decorator.
+ *
+ * @see Instantiator
+ */
+@VaadinServiceScoped
+@VaadinServiceEnabled
+public class CdiInstantiatorFactory implements InstantiatorFactory {
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Override
+    public Instantiator createInstantitor(VaadinService service) {
+        if (!getServiceClass().isAssignableFrom(service.getClass())) {
+            return null;
+        }
+
+        return new CdiInstantiator(beanManager, service);
+    }
+
+    public Class<? extends VaadinService> getServiceClass() {
+        return CdiVaadinServletService.class;
+    }
+
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 import com.vaadin.cdi.annotation.VaadinServiceEnabled;
 import com.vaadin.cdi.context.ServiceUnderTestContext;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.ServiceInitEvent;
@@ -106,7 +107,9 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
 
     @Inject
     @VaadinServiceEnabled
-    private CdiInstantiator instantiator;
+    private CdiInstantiatorFactory instantiatorFactory;
+
+    private Instantiator instantiator;
 
     @Inject
     private SomeCdiBean singleton;
@@ -120,8 +123,7 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
     public void setUp() {
         serviceUnderTestContext = new ServiceUnderTestContext(beanManager);
         serviceUnderTestContext.activate();
-        CdiVaadinServletService service = serviceUnderTestContext.getService();
-        Assertions.assertTrue(instantiator.init(service));
+        instantiator = instantiatorFactory.createInstantitor(VaadinService.getCurrent());
     }
 
     @AfterEach


### PR DESCRIPTION
Changes related to Flow 24 deprecated code removal https://github.com/vaadin/flow/issues/15665