### PR TITLE
chore: Remove not needed apache snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>apache-snapshot-repository</id>
-            <url>https://repository.apache.org/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
DeltaSpike snapshot is not used anymore, so no need for a snapshot repo.