### PR TITLE
test: added support for testing with Jakarta EE 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Execute `mvn clean install -DskipTests` in the root directory to build vaadin-cd
 
 Execute `mvn -pl vaadin-cdi-itest -Ptomee verify` in the root directory to run integration tests.
 
+Test can be executed against the following containers, activating the specific profile:
+
+* Wildfly Jakarta EE 9: `-Pwidfly`
+* Wildfly Jakarta EE 10: `-Pwidfly,jakartaee-10`
+* OpenLiberty Jakarta EE 9: `-Pliberty`
+* OpenLiberty Jakarta EE 10: `-Pliberty,jakartaee-10`
+* Payara Jakarta EE 10: `-Ppayara`
+  (Payara does not support Jakarta EE 9)
+* TomEE Jakarta EE 9: `-Ptomee`
+  (TomEE does not yet support Jakarta EE 10)
+
 ## Issue tracking
 
 If you find an issue, please report it in the [GitHub issue tracker](https://github.com/vaadin/cdi/issues).

--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -16,6 +16,9 @@
         <surefire.groups></surefire.groups>
         <surefire.excludedGroups>com.vaadin.cdi.itest.SlowTests</surefire.excludedGroups>
         <wildfly.version>26.1.2.Final</wildfly.version>
+        <openliberty.version>22.0.0.13</openliberty.version>
+        <openliberty.template>jakartaee9</openliberty.template>
+        <openliberty.runtimeArtifactGroupId>io.openliberty</openliberty.runtimeArtifactGroupId>
     </properties>
 
     <pluginRepositories>
@@ -325,8 +328,14 @@
                                     <goal>configure-arquillian</goal>
                                 </goals>
                                 <configuration>
+                                    <runtimeArtifact>
+                                        <groupId>${openliberty.runtimeArtifactGroupId}</groupId>
+                                        <artifactId>openliberty-runtime</artifactId>
+                                        <version>${openliberty.version}</version>
+                                        <type>zip</type>
+                                    </runtimeArtifact>
                                     <useOpenLiberty>true</useOpenLiberty>
-                                    <template>jakartaee9</template>
+                                    <template>${openliberty.template}</template>
                                     <features>
                                         <feature>localConnector-1.0</feature>
                                     </features>
@@ -370,6 +379,23 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jakartaee-10</id>
+            <properties>
+                <!-- Widlfy -->
+                <wildfly.version>27.0.1.Final</wildfly.version>
+
+                <!-- OpenLiberty -->
+                <openliberty.version>22.0.0.13-beta</openliberty.version>
+                <openliberty.template>jakartaee10</openliberty.template>
+                <openliberty.runtimeArtifactGroupId>io.openliberty.beta</openliberty.runtimeArtifactGroupId>
+
+                <!-- Tomee: no support for Jakarta EE 10 at the moment -->
+
+                <!-- Payara: no support for Jakarta EE 9 -->
+
+            </properties>
         </profile>
         <profile>
             <id>local-run</id>

--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -246,6 +246,11 @@
                     <version>3.0.alpha6</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>
@@ -264,7 +269,7 @@
                                         <artifactItem>
                                             <groupId>fish.payara.distributions</groupId>
                                             <artifactId>payara</artifactId>
-                                            <version>6.2022.1.Alpha3</version>
+                                            <version>6.2023.1</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>target</outputDirectory>
@@ -283,6 +288,7 @@
                             <groups>${surefire.groups}</groups>
                             <systemPropertyVariables>
                                 <payara.home>${project.build.directory}/payara6</payara.home>
+                                <arquillian.launch>payara</arquillian.launch>
                                 <vaadin.bowerMode>true</vaadin.bowerMode>
                                 <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
                             </systemPropertyVariables>

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorCustomizeView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/instantiatorcustomize/InstantiatorCustomizeView.java
@@ -18,10 +18,12 @@ package com.vaadin.cdi.itest.instantiatorcustomize;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("")
+@CdiComponent
 public class InstantiatorCustomizeView extends Div {
     public static final String VIEW = "VIEW";
     public static final String CUSTOMIZED = "CUSTOMIZED";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/DeploymentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/invaliddeployment/DeploymentView.java
@@ -16,9 +16,11 @@
 
 package com.vaadin.cdi.itest.invaliddeployment;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("")
+@CdiComponent
 public class DeploymentView extends Div {
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/PushComponent.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.cdi.annotation.VaadinServiceScoped;
@@ -36,6 +37,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 
+@CdiComponent
 public class PushComponent extends Div {
 
     public static final String RUN_BACKGROUND = "RUN_BACKGROUND";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketPushView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketPushView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.push;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -27,6 +28,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Transport;
 
 @Route("websocket")
+@CdiComponent
 public class WebsocketPushView extends Div {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketXhrPushView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/WebsocketXhrPushView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.push;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -27,6 +28,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Transport;
 
 @Route("websocket-xhr")
+@CdiComponent
 public class WebsocketXhrPushView extends Div {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/regression/RemoveOldContentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/regression/RemoveOldContentView.java
@@ -1,5 +1,6 @@
 package com.vaadin.cdi.itest.regression;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -11,6 +12,7 @@ import com.vaadin.flow.router.RouterLayout;
 
 @UIScoped
 @Route("")
+@CdiComponent
 public class RemoveOldContentView extends Div
         implements RouterLayout {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/BeanNoOwner.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/BeanNoOwner.java
@@ -17,9 +17,11 @@ package com.vaadin.cdi.itest.routecontext;
 
 import java.util.UUID;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 
 @RouteScoped
+@CdiComponent
 public class BeanNoOwner extends AbstractCountedBean {
 
     public BeanNoOwner() {

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ChildNoOwnerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ChildNoOwnerView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.routecontext;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
@@ -25,6 +26,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 
 @Route(value = "child-no-owner", layout = ParentNoOwnerView.class)
+@CdiComponent
 public class ChildNoOwnerView extends Div {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubButton.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubButton.java
@@ -17,12 +17,14 @@ package com.vaadin.cdi.itest.routecontext;
 
 import java.util.UUID;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.NativeButton;
 
 @RouteScoped
 @RouteScopeOwner(ErrorHandlerView.class)
+@CdiComponent
 public class CustomExceptionSubButton extends AbstractCountedView {
 
     public CustomExceptionSubButton() {

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubDiv.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/CustomExceptionSubDiv.java
@@ -17,11 +17,13 @@ package com.vaadin.cdi.itest.routecontext;
 
 import java.util.UUID;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 
 @RouteScoped
 @RouteScopeOwner(ErrorHandlerView.class)
+@CdiComponent
 public class CustomExceptionSubDiv extends AbstractCountedView {
 
     public CustomExceptionSubDiv() {

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailApartView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailApartView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.routecontext;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
@@ -30,6 +31,7 @@ import com.vaadin.flow.router.RouterLink;
 
 @RouteScoped
 @Route(value = "apart", layout = MasterView.class)
+@CdiComponent
 public class DetailApartView extends AbstractCountedView implements AfterNavigationObserver {
 
     public static final String MASTER = "master";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailAssignedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/DetailAssignedView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.routecontext;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
@@ -31,6 +32,7 @@ import com.vaadin.flow.router.RouterLink;
 @RouteScoped
 @RouteScopeOwner(MasterView.class)
 @Route(value = "assigned", layout = MasterView.class)
+@CdiComponent
 public class DetailAssignedView extends AbstractCountedView implements AfterNavigationObserver {
 
     public static final String MASTER = "master";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorHandlerView.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletResponse;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.Component;
@@ -33,6 +34,7 @@ import com.vaadin.flow.router.RouterLink;
 @RouteScoped
 @RouteScopeOwner(ErrorParentView.class)
 @ParentLayout(ErrorParentView.class)
+@CdiComponent
 public class ErrorHandlerView extends AbstractCountedView
         implements HasErrorParameter<CustomException> {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorParentView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.routecontext;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.router.Route;
@@ -27,6 +28,7 @@ import com.vaadin.flow.router.RouterLink;
 @RouteScoped
 @RouteScopeOwner(ErrorParentView.class)
 @Route("error-layout")
+@CdiComponent
 public class ErrorParentView extends AbstractCountedView
         implements RouterLayout {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ErrorView.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
@@ -23,6 +24,7 @@ import com.vaadin.flow.router.Route;
 
 @RouteScoped
 @Route("error")
+@CdiComponent
 public class ErrorView extends AbstractCountedView
         implements BeforeEnterObserver {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/EventView.java
@@ -22,6 +22,7 @@ import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
@@ -31,6 +32,7 @@ import com.vaadin.flow.router.Route;
 
 @Route("event")
 @RouteScoped
+@CdiComponent
 public class EventView extends Div {
 
     public static final String FIRE = "FIRE";
@@ -38,6 +40,7 @@ public class EventView extends Div {
 
     @RouteScoped
     @RouteScopeOwner(EventView.class)
+    @CdiComponent
     public static class ObserverLabel extends Label {
         private void onPrintEvent(@Observes PrintEvent printEvent) {
             setText(printEvent.getMessage());

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/InvalidView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/InvalidView.java
@@ -17,11 +17,13 @@ package com.vaadin.cdi.itest.routecontext;
 
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("invalid-injection")
+@CdiComponent
 public class InvalidView extends Div {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -28,6 +29,7 @@ import com.vaadin.flow.router.Route;
 
 @Route(value = "layout-event", layout = EventObserverLayout.class)
 @RouteScoped
+@CdiComponent
 public class LayoutEventView extends Div {
 
     public static final String FIRE = "FIRE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutEventView2.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -28,6 +29,7 @@ import com.vaadin.flow.router.Route;
 
 @Route(value = "layout-event-2", layout = EventObserverLayout.class)
 @RouteScoped
+@CdiComponent
 public class LayoutEventView2 extends Div {
 
     public static final String FIRE = "FIRE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MasterView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.routecontext;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
@@ -33,6 +34,7 @@ import com.vaadin.flow.router.RouterLink;
 @RouteScoped
 @Route("")
 @RoutePrefix("master")
+@CdiComponent
 public class MasterView extends AbstractCountedView
         implements RouterLayout, AfterNavigationObserver {
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ParentNoOwnerView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/ParentNoOwnerView.java
@@ -17,6 +17,7 @@ package com.vaadin.cdi.itest.routecontext;
 
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
@@ -24,6 +25,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RouterLink;
 
 @Route("parent-no-owner")
+@CdiComponent
 public class ParentNoOwnerView extends Div implements RouterLayout {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PostponeView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PostponeView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.routecontext;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
@@ -28,6 +29,7 @@ import com.vaadin.flow.router.RouterLink;
 
 @Route("postpone")
 @RouteScoped
+@CdiComponent
 public class PostponeView extends AbstractCountedView implements BeforeLeaveObserver {
 
     public static final String NAVIGATE = "NAVIGATE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshBean.java
@@ -19,11 +19,13 @@ import java.util.UUID;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.cdi.annotation.RouteScoped;
 
 @RouteScoped
 @RouteScopeOwner(PreserveOnRefreshView.class)
+@CdiComponent
 public class PreserveOnRefreshBean extends AbstractCountedBean {
 
     @PostConstruct

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/PreserveOnRefreshView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.routecontext;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScopeOwner;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.html.Div;
@@ -26,6 +27,7 @@ import com.vaadin.flow.router.Route;
 
 @PreserveOnRefresh
 @Route(value = "preserve-on-refresh", layout = MainLayout.class)
+@CdiComponent
 public class PreserveOnRefreshView extends Div {
 
     @Inject

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RerouteView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RerouteView.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.cdi.itest.routecontext;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
@@ -23,6 +24,7 @@ import com.vaadin.flow.router.Route;
 
 @Route("reroute")
 @RouteScoped
+@CdiComponent
 public class RerouteView extends AbstractCountedView implements BeforeEnterObserver {
 
     @Override

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/RootView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.routecontext;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
@@ -26,6 +27,7 @@ import com.vaadin.flow.router.RouterLink;
 
 @Route(value = "", layout = MainLayout.class)
 @RouteScoped
+@CdiComponent
 public class RootView extends AbstractCountedView {
 
     public static final String MASTER = "master";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/BootstrapCustomizeView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/BootstrapCustomizeView.java
@@ -16,9 +16,11 @@
 
 package com.vaadin.cdi.itest.service;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("bootstrap")
+@CdiComponent
 public class BootstrapCustomizeView extends Div {
 }

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/BootstrapCustomizer.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/BootstrapCustomizer.java
@@ -18,9 +18,11 @@ package com.vaadin.cdi.itest.service;
 
 import jakarta.enterprise.event.Observes;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.communication.IndexHtmlResponse;
 
+@CdiComponent
 public class BootstrapCustomizer {
 
     public static final String APPENDED_ID = "TEST_ID";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/EventObserver.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/EventObserver.java
@@ -19,11 +19,13 @@ package com.vaadin.cdi.itest.service;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.itest.Counter;
 import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.UIInitEvent;
 
+@CdiComponent
 public class EventObserver {
     @Inject
     private Counter counter;

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/ServiceView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/service/ServiceView.java
@@ -18,12 +18,14 @@ package com.vaadin.cdi.itest.service;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.VaadinSession;
 
 @Route("")
+@CdiComponent
 public class ServiceView extends Div {
 
     public static final String EXPIRE = "EXPIRE";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/sessioncontext/SessionContextView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/sessioncontext/SessionContextView.java
@@ -21,6 +21,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.cdi.itest.Counter;
 import com.vaadin.flow.component.html.Div;
@@ -31,6 +32,7 @@ import com.vaadin.flow.server.VaadinSession;
 
 
 @Route("")
+@CdiComponent
 public class SessionContextView extends Div {
 
     public static final String SETVALUEBTN_ID = "setvalbtn";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/smoke/CdiView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/smoke/CdiView.java
@@ -22,12 +22,14 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 @Route("")
+@CdiComponent
 public class CdiView extends Div {
     @Inject
     private HelloProvider helloProvider;

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/template/TestTemplate.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/template/TestTemplate.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -34,6 +35,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 @JsModule("./test-template.js")
 @UIScoped
 @Route("")
+@CdiComponent
 public class TestTemplate extends PolymerTemplate<TemplateModel> {
     private @Id("input") Input input;
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIContextRootView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIContextRootView.java
@@ -20,6 +20,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.itest.uicontext.UIScopedLabel.SetTextEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -29,6 +30,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 
 @Route("")
+@CdiComponent
 public class UIContextRootView extends Div {
 
     public static final String CLOSE_UI_BTN = "CLOSE_UI_BTN";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UINormalScopedBeanView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UINormalScopedBeanView.java
@@ -19,6 +19,7 @@ package com.vaadin.cdi.itest.uicontext;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.NormalUIScoped;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.flow.component.UI;
@@ -27,6 +28,7 @@ import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.router.Route;
 
 @Route("normalscopedbean")
+@CdiComponent
 public class UINormalScopedBeanView extends Div {
 
     public static final String UIID_LABEL = "UIID_LABEL";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopeInjecterView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopeInjecterView.java
@@ -19,10 +19,12 @@ package com.vaadin.cdi.itest.uicontext;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("injecter")
+@CdiComponent
 public class UIScopeInjecterView extends Div {
     @Inject
     private UIScopedLabel label;

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopedLabel.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopedLabel.java
@@ -20,12 +20,14 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.cdi.itest.Counter;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Label;
 
 @UIScoped
+@CdiComponent
 public class UIScopedLabel extends Label {
 
     public static final String DESTROY_COUNT = "UIScopedLabelDestroy";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uicontext/UIScopedView.java
@@ -18,6 +18,7 @@ package com.vaadin.cdi.itest.uicontext;
 
 import jakarta.annotation.PostConstruct;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
@@ -27,6 +28,7 @@ import com.vaadin.flow.router.RouterLink;
 
 @Route("uiscoped")
 @UIScoped
+@CdiComponent
 public class UIScopedView extends Div {
 
     public static final String VIEWSTATE_LABEL = "VIEWSTATE_LABEL";

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uievents/UIEventsView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/uievents/UIEventsView.java
@@ -23,6 +23,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.flow.component.PollEvent;
 import com.vaadin.flow.component.UI;
@@ -34,6 +35,7 @@ import com.vaadin.flow.router.Route;
 
 @Route("uievents")
 @UIScoped
+@CdiComponent
 public class UIEventsView extends Div implements AfterNavigationObserver {
 
     public static final String POLL_FROM_CLIENT = "POLL_FROM_CLIENT";

--- a/vaadin-cdi-itest/src/test/resources/payara/glassfish-web.xml
+++ b/vaadin-cdi-itest/src/test/resources/payara/glassfish-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN"
+        "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+    <class-loader delegate="false"/>
+</glassfish-web-app>


### PR DESCRIPTION
Updated integration tests POM to be able to run validation against containers for both Jakarta EE 9 and 10 version
Update source code to work with annotated bean discovery mode, since this is the default starting with Jakarta EE 10.
Added a workaround to avoid issues with SLF4J when running tests with Payara.

DO NOT SQUASH