### PR TITLE
test: upgrade tomee to 8.x

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -144,7 +144,7 @@
         <profile>
             <id>tomee</id>
             <properties>
-                <apache-tomee.version>7.0.4</apache-tomee.version>
+                <apache-tomee.version>8.0.14</apache-tomee.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
The version in use has issues with ASM.
The problem can be fix upgrading tomee to the latest 7.1.x, that however is EOL, or to to 8.0.x