### PR TITLE
test: resolve web archive dependencies all together

### DIFF
--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/ArchiveProvider.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/ArchiveProvider.java
@@ -19,8 +19,6 @@ package com.vaadin.cdi.itest;
 import java.io.File;
 import java.util.function.Consumer;
 
-import org.jboss.arquillian.container.test.api.BeforeDeployment;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -48,16 +46,11 @@ public class ArchiveProvider {
         PomEquippedResolveStage pom = Maven.configureResolver().workOffline()
                 .loadPomFromFile("target/effective-pom.xml");
         WebArchive archive = ShrinkWrap.create(WebArchive.class, warName + ".war")
-                .addAsLibraries(pom.resolve("com.vaadin:vaadin-cdi")
-                        .withTransitivity().asFile())
-                .addAsLibraries(pom.resolve("com.vaadin:flow-server")
-                        .withTransitivity().asFile())
-                .addAsLibraries(pom.resolve("com.vaadin:flow-client")
-                        .withTransitivity().asFile())
-                .addAsLibraries(pom.resolve("com.vaadin:flow-html-components")
-                        .withTransitivity().asFile())
-                .addAsLibraries(pom.resolve("com.vaadin:flow-polymer-template")
-                        .withTransitivity().asFile())
+                .addAsLibraries(pom.resolve(
+                        "com.vaadin:vaadin-cdi", "com.vaadin:flow-server",
+                        "com.vaadin:flow-client", "com.vaadin:flow-html-components",
+                        "com.vaadin:flow-polymer-template"
+                ).withTransitivity().asFile())
                 .addAsWebInfResource(EmptyAsset.INSTANCE,
                         ArchivePaths.create("beans.xml"))
                 .addClasses(Counter.class, CounterFilter.class);


### PR DESCRIPTION
Resolving dependency one by one may cause failures if artifacts have transitive dependency to other libraries but in different versions. In this case, resolution fails because the resolver is working offline, but only the winning dependency from effective pom is actually downloaded on CI server.
For example, if flow-server has a transitive dependency to library X at version 1 and flow-polymer-template defines it at version 2, then version 2 is downloaded. However, when resolving flow-server alone the resolver wants to download version 1 since it has no knowledge of version 2, but version 1 potentially has not been previously downloaded. Resolving all dependencies together resolves the issue, since the correct version of the transitive dependencies are computed.
