### PR TITLE
fix: provide default MenuAccessControl instance

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/AbstractCdiInstantiator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/AbstractCdiInstantiator.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 
 abstract public class AbstractCdiInstantiator implements Instantiator {
 
@@ -76,6 +77,13 @@ abstract public class AbstractCdiInstantiator implements Instantiator {
             });
         }
         return lookup.lookupOrElseGet(getDelegate()::getI18NProvider);
+    }
+
+    @Override
+    public MenuAccessControl getMenuAccessControl() {
+        final BeanLookup<MenuAccessControl> lookup = new BeanLookup<>(
+                getBeanManager(), MenuAccessControl.class, BeanLookup.SERVICE);
+        return lookup.lookupOrElseGet(getDelegate()::getMenuAccessControl);
     }
 
     private static Logger getLogger() {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorDefaultsTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorDefaultsTest.java
@@ -1,0 +1,62 @@
+package com.vaadin.cdi;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+import com.vaadin.cdi.annotation.VaadinServiceScoped;
+import com.vaadin.cdi.context.ServiceUnderTestContext;
+import com.vaadin.cdi.context.VaadinServiceScopedContext;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+
+@EnableWeld
+public class CdiInstantiatorDefaultsTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(
+            CdiInstantiatorFactory.class, CdiInstantiator.class,
+            VaadinServiceScopedContext.ContextualStorageManager.class
+    ).activate(VaadinServiceScoped.class).build();
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Inject
+    @VaadinServiceEnabled
+    private CdiInstantiatorFactory instantiatorFactory;
+
+    private Instantiator instantiator;
+
+    private ServiceUnderTestContext serviceUnderTestContext;
+
+    @BeforeEach
+    public void setUp() {
+        serviceUnderTestContext = new ServiceUnderTestContext(beanManager);
+        serviceUnderTestContext.activate();
+        instantiator = instantiatorFactory.createInstantitor(VaadinService.getCurrent());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        serviceUnderTestContext.tearDownAll();
+    }
+
+    @Test
+    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+        MenuAccessControl menuAccessControl = instantiator
+                .getMenuAccessControl();
+        Assertions.assertNotNull(menuAccessControl);
+        Assertions.assertInstanceOf(DefaultMenuAccessControl.class, menuAccessControl);
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -180,7 +180,7 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
     }
 
     @Test
-    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+    public void getMenuAccessControl_beanEnabled_instanceReturned() {
         MenuAccessControl menuAccessControl = instantiator
                 .getMenuAccessControl();
         Assertions.assertNotNull(menuAccessControl);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -38,6 +38,8 @@ import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,6 +113,21 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
 
     }
 
+    @VaadinServiceEnabled
+    public static class TestMenuAccessControl implements MenuAccessControl {
+
+        @Override
+        public void setPopulateClientSideMenu(
+                PopulateClientMenu populateClientSideMenu) {
+
+        }
+
+        @Override
+        public PopulateClientMenu getPopulateClientSideMenu() {
+            return null;
+        }
+    }
+
     @Singleton
     public static class ServiceInitObserver {
 
@@ -160,6 +177,14 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
         I18NProvider i18NProvider = instantiator.getI18NProvider();
         Assertions.assertNotNull(i18NProvider);
         Assertions.assertTrue((i18NProvider instanceof I18NTestProvider));
+    }
+
+    @Test
+    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+        MenuAccessControl menuAccessControl = instantiator
+                .getMenuAccessControl();
+        Assertions.assertNotNull(menuAccessControl);
+        Assertions.assertInstanceOf(TestMenuAccessControl.class, menuAccessControl);
     }
 
     @Test


### PR DESCRIPTION
A MenuAccessControl instance is required when operating with MenuConfiguration. This change provides a default implementation if the user project does not define a specialized bean.
