### PR TITLE
feat: detect specific Executor for VaadinService

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -332,6 +332,7 @@
                                     <useOpenLiberty>true</useOpenLiberty>
                                     <template>${openliberty.template}</template>
                                     <features>
+                                        <feature>jakartaee-10.0</feature>
                                         <feature>localConnector-1.0</feature>
                                     </features>
                                 </configuration>

--- a/vaadin-cdi-itest/src/test/resources/liberty/server.xml
+++ b/vaadin-cdi-itest/src/test/resources/liberty/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>jakartaee-9.1</feature>
+        <feature>jakartaee-10.0</feature>
         <feature>localConnector-1.0</feature>
     </featureManager>
 

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -36,6 +36,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinTaskExecutorSelector.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinTaskExecutorSelector.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+
+/**
+ * Utility class responsible for selecting an {@link Executor} for task
+ * execution within a Vaadin-based application.
+ * <p>
+ * The class attempts to provide a custom {@link Executor} that is marked with
+ * the {@link VaadinServiceEnabled} qualifier, leveraging the CDI (Contexts and
+ * Dependency Injection) mechanism for bean resolution. If such a custom
+ * executor is resolvable, it is returned. Otherwise, a potential container
+ * provided {@link ManagedExecutorService} is used as a fallback executor.
+ */
+class VaadinTaskExecutorSelector {
+
+    @Resource
+    ManagedExecutorService managedExecutor;
+
+    @Inject
+    @VaadinServiceEnabled
+    Instance<Executor> customExecutor;
+
+    /**
+     * Provides an {@link Optional} containing an {@link Executor}, based on the
+     * resolvability of a custom {@link Executor} annotated with
+     * {@code @VaadinServiceEnabled}. If a custom executor is not resolvable,
+     * the method falls back to a default {@link ManagedExecutorService}.
+     *
+     * @return an {@link Optional} containing the selected {@link Executor}, or
+     *         an empty {@link Optional} if no executor is available.
+     */
+    Optional<Executor> getExecutor() {
+        if (customExecutor.isResolvable()) {
+            LoggerFactory.getLogger(VaadinTaskExecutorSelector.class).debug(
+                    "Using custom Vaadin Executor {}",
+                    customExecutor.getHandle().getBean());
+            return Optional.of(customExecutor.get());
+        } else if (customExecutor.isAmbiguous()) {
+            String candidates = customExecutor.handlesStream()
+                    .map(handle -> handle.getBean().toString())
+                    .collect(Collectors.joining(", ", "[", "]"));
+            String message = String.format(
+                    "Multiple Executor beans annotated with @%1$s found: %2$s. "
+                            + "Please make sure a single instance is resolvable.",
+                    VaadinServiceEnabled.class.getSimpleName(), candidates);
+            throw new IllegalStateException(message);
+        }
+        if (managedExecutor != null) {
+            LoggerFactory.getLogger(VaadinTaskExecutorSelector.class)
+                    .debug("Using container Managed Executor");
+        }
+        return Optional.ofNullable(managedExecutor);
+    }
+}

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceExecutorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceExecutorTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.cdi.context.ServiceUnderTestContext;
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.ServiceException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnableWeld
+public class CdiVaadinServletServiceExecutorTest {
+
+    @Nested
+    class UseDefaultManagedExecutor extends BaseTest {
+
+        @WeldSetup
+        public WeldInitiator weld = withManagedExecutorService().build();
+
+        @Test
+        void getExecutor_serviceInitialized_cdiManagedExecutorReturned()
+                throws ServiceException {
+            initService(beanManager);
+            Executor executor = service.getExecutor();
+            Assertions.assertSame(managedExecutorService, executor);
+        }
+    }
+
+    @Nested
+    class UseVaadinServiceEnabledExecutor extends BaseTest {
+
+        @WeldSetup
+        public WeldInitiator weld = withManagedExecutorService()
+                .addBeans(customTaskExecutorBean()).build();
+
+        @Test
+        void getExecutor_serviceInitialized_cdiManagedExecutorReturned()
+                throws Exception {
+            initService(beanManager);
+            Executor executor = service.getExecutor();
+            Assertions.assertSame(customExecutor, executor);
+        }
+    }
+
+    @Nested
+    class UseDefaultVaadinExecutor extends BaseTest {
+
+        @WeldSetup
+        public WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+
+        @Test
+        void getExecutor_serviceInitialized_cdiManagedExecutorReturned()
+                throws ServiceException {
+            initService(beanManager);
+            Executor executor = service.getExecutor();
+            Assertions.assertNotNull(executor);
+            Assertions.assertNotSame(managedExecutorService, executor);
+            Assertions.assertNotSame(customExecutor, executor);
+        }
+    }
+
+    @Nested
+    class AmbiguousVaadinServiceEnabledExecutor extends BaseTest {
+
+        public WeldInitiator weld = withManagedExecutorService()
+                .addBeans(
+                        customTaskExecutorBean(
+                                b -> b.name("customVaadinExecutor")),
+                        customTaskExecutorBean(b -> b.name("otherExecutor")))
+                .build();
+
+        @Test
+        void deploymentValidation_throwsException() throws Exception {
+            var initWeldMethod = ReflectTools.findMethod(WeldInitiator.class,
+                    "initWeld", Object.class);
+            initWeldMethod.setAccessible(true);
+            Throwable error = Assertions.assertThrows(
+                    InvocationTargetException.class,
+                    () -> initWeldMethod.invoke(weld, this));
+            error = error.getCause();
+            while (error != null && !(error instanceof IllegalStateException)) {
+                error = error.getCause();
+            }
+            assertNotNull(error);
+            assertTrue(error.getMessage().contains("at most one Executor bean"));
+            assertTrue(error.getMessage().contains("@VaadinServiceEnabled"));
+        }
+    }
+
+    // Multiple @VaadinServiceEnabled beans, alternatives are ignored
+    @Nested
+    class AmbiguousVaadinServiceEnabledWithAlternativeExecutor
+            extends BaseTest {
+
+        Executor expectedExecutor = Mockito.mock(Executor.class);
+
+        @WeldSetup
+        public WeldInitiator weld = withManagedExecutorService().addBeans(
+                customTaskExecutorBean(
+                        b -> b.name("customVaadinExecutor").alternative(true)),
+                customTaskExecutorBean(b -> b.name("alternativeVaadinExecutor")
+                        .creating(expectedExecutor)))
+                .build();
+
+        @Test
+        void getExecutor_serviceInitialized_cdiManagedExecutorReturned()
+                throws ServiceException {
+            initService(beanManager);
+            Executor executor = service.getExecutor();
+            Assertions.assertSame(expectedExecutor, executor);
+        }
+    }
+
+    private static abstract class BaseTest {
+
+        ManagedExecutorService managedExecutorService = Mockito
+                .mock(ManagedExecutorService.class);
+
+        Executor customExecutor = Mockito.mock(Executor.class);
+
+        @Inject
+        BeanManager beanManager;
+
+        CdiVaadinServletService service;
+
+        void initService(BeanManager beanManager) throws ServiceException {
+            ServiceUnderTestContext serviceUnderTestContext = new ServiceUnderTestContext(
+                    beanManager);
+            serviceUnderTestContext.activate();
+            service = serviceUnderTestContext.getService();
+            service.init();
+        }
+
+        WeldInitiator.Builder withManagedExecutorService() {
+            return WeldInitiator.from(new Weld())
+                    // Simulate @Resource injection without name or lookup into
+                    // VaadinTaskExecutorSelector bean in weld mock environment
+                    .bindResource(
+                            "java:comp/env/com.vaadin.cdi.VaadinTaskExecutorSelector/managedExecutor",
+                            managedExecutorService);
+        }
+
+        Bean<?> customTaskExecutorBean() {
+            return customTaskExecutorBean(unused -> {
+            });
+        }
+
+        Bean<?> customTaskExecutorBean(
+                Consumer<MockBean.Builder<Executor>> customizer) {
+            MockBean.Builder<Executor> builder = MockBean.<Executor> builder()
+                    .types(Executor.class).scope(Singleton.class)
+                    .addQualifier(BeanLookup.SERVICE).creating(customExecutor);
+            customizer.accept(builder);
+            return builder.build();
+        }
+
+    }
+
+}


### PR DESCRIPTION
Enhances CDI VaadinService implementation trying to detect the best Executor option available on the container. It first looks for an Executor bean annotated with `@VaadinServiceEnabled` and then falls back to the container ManagedExecutorService.

Closes #468
