### PR TITLE
fix: prevent startup failures on non-Jakarta EE compliant environments

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -15,6 +15,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <surefire.groups></surefire.groups>
         <surefire.excludedGroups>com.vaadin.cdi.itest.SlowTests</surefire.excludedGroups>
+        <apache-tomcat.version>11.0.8</apache-tomcat.version>
         <apache-tomee.version>10.1.0</apache-tomee.version>
         <wildfly.version>36.0.1.Final</wildfly.version>
         <openliberty.version>25.0.0.6</openliberty.version>
@@ -374,6 +375,94 @@
                                 <arquillian.launch>liberty_managed</arquillian.launch>
                             </systemPropertyVariables>
                             <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>tomcat-weld</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-10</artifactId>
+                    <version>1.2.3.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <!-- Weld servlet for testing CDI injections -->
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-shaded</artifactId>
+                    <version>${weld.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.enterprise.concurrent</groupId>
+                    <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${maven-dependency-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.apache.tomcat</groupId>
+                                            <artifactId>tomcat</artifactId>
+                                            <version>${apache-tomcat.version}</version>
+                                            <type>zip</type>
+                                            <outputDirectory>target</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>setup-tomcat-users</id>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <phase>process-test-classes</phase>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/src/test/resources/tomcat</directory>
+                                            <includes>
+                                                <include>tomcat-users.xml</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${project.build.directory}/apache-tomcat-${apache-tomcat.version}/conf</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <configuration>
+                            <excludedGroups>com.vaadin.cdi.itest.NeedsCDICompliantContainer,${surefire.excludedGroups}</excludedGroups>
+                            <groups>${surefire.groups}</groups>
+                            <systemPropertyVariables>
+                                <arquillian.launch>tomcat-weld</arquillian.launch>
+                                <catalina.home>${project.build.directory}/apache-tomcat-${apache-tomcat.version}</catalina.home>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/CustomSchedulerPushComponent.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/CustomSchedulerPushComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.push;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+
+@CdiComponent
+public class CustomSchedulerPushComponent extends PushComponent {
+
+    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors
+            .newScheduledThreadPool(4);
+
+    @Override
+    public ScheduledExecutorService getExecutorService() {
+        return EXECUTOR_SERVICE;
+    }
+
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/ManagedExecutorPushComponent.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/push/ManagedExecutorPushComponent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest.push;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+
+@CdiComponent
+public class ManagedExecutorPushComponent extends PushComponent {
+
+
+    @Resource
+    private ManagedScheduledExecutorService executorService;
+
+    @Override
+    public ScheduledExecutorService getExecutorService() {
+        return executorService;
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/NeedsCDICompliantContainer.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/NeedsCDICompliantContainer.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.cdi.itest;
+
+public interface NeedsCDICompliantContainer {
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushTest.java
@@ -53,7 +53,7 @@ public class PushTest extends AbstractCdiTest {
     @Test
     public void wsWithXhrBackgroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket-xhr");
-        click(ManagedExecutorPushComponent.RUN_BACKGROUND);
+        click(PushComponent.RUN_BACKGROUND);
         waitForPush();
         assertAllExceptRequestAndSessionActive();
     }
@@ -61,7 +61,7 @@ public class PushTest extends AbstractCdiTest {
     @Test
     public void wsWithXhrForegroundAllContextsActive() {
         getDriver().get(getTestURL() + "websocket-xhr");
-        click(ManagedExecutorPushComponent.RUN_FOREGROUND);
+        click(PushComponent.RUN_FOREGROUND);
         assertContextActive(RequestScoped.class, true);
         assertContextActive(SessionScoped.class, true);
         assertContextActive(ApplicationScoped.class, true);
@@ -71,7 +71,7 @@ public class PushTest extends AbstractCdiTest {
     @Test
     public void wsNoXhrBackgroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket");
-        click(ManagedExecutorPushComponent.RUN_BACKGROUND);
+        click(PushComponent.RUN_BACKGROUND);
         waitForPush();
         assertAllExceptRequestAndSessionActive();
     }
@@ -79,7 +79,7 @@ public class PushTest extends AbstractCdiTest {
     @Test
     public void wsNoXhrForegroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket");
-        click(ManagedExecutorPushComponent.RUN_FOREGROUND);
+        click(PushComponent.RUN_FOREGROUND);
         assertAllExceptRequestAndSessionActive();
     }
 

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushWithoutManagedExecutorTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushWithoutManagedExecutorTest.java
@@ -26,27 +26,26 @@ import net.jcip.annotations.NotThreadSafe;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 
 import com.vaadin.cdi.annotation.RouteScoped;
 import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.cdi.itest.push.CustomSchedulerPushComponent;
 import com.vaadin.cdi.itest.push.ManagedExecutorPushComponent;
 import com.vaadin.cdi.itest.push.PushComponent;
 import com.vaadin.cdi.itest.push.WebsocketPushView;
 import com.vaadin.cdi.itest.push.WebsocketXhrPushView;
 
 @NotThreadSafe
-@Category(NeedsCDICompliantContainer.class)
-public class PushTest extends AbstractCdiTest {
+public class PushWithoutManagedExecutorTest extends AbstractCdiTest {
 
     @Deployment(testable = false)
-    public static WebArchive deployment() {
+    public static WebArchive deploymentTomcatWeld() {
         return ArchiveProvider.createWebArchive("push", webArchive -> webArchive
                 .addClasses(WebsocketPushView.class, WebsocketXhrPushView.class,
-                        PushComponent.class, ManagedExecutorPushComponent.class)
+                        PushComponent.class, CustomSchedulerPushComponent.class)
                 .addAsResource(new File("target/classes/META-INF")));
     }
 

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushWithoutManagedExecutorTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/PushWithoutManagedExecutorTest.java
@@ -33,7 +33,6 @@ import com.vaadin.cdi.annotation.UIScoped;
 import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.cdi.itest.push.CustomSchedulerPushComponent;
-import com.vaadin.cdi.itest.push.ManagedExecutorPushComponent;
 import com.vaadin.cdi.itest.push.PushComponent;
 import com.vaadin.cdi.itest.push.WebsocketPushView;
 import com.vaadin.cdi.itest.push.WebsocketXhrPushView;
@@ -52,7 +51,7 @@ public class PushWithoutManagedExecutorTest extends AbstractCdiTest {
     @Test
     public void wsWithXhrBackgroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket-xhr");
-        click(ManagedExecutorPushComponent.RUN_BACKGROUND);
+        click(PushComponent.RUN_BACKGROUND);
         waitForPush();
         assertAllExceptRequestAndSessionActive();
     }
@@ -60,7 +59,7 @@ public class PushWithoutManagedExecutorTest extends AbstractCdiTest {
     @Test
     public void wsWithXhrForegroundAllContextsActive() {
         getDriver().get(getTestURL() + "websocket-xhr");
-        click(ManagedExecutorPushComponent.RUN_FOREGROUND);
+        click(PushComponent.RUN_FOREGROUND);
         assertContextActive(RequestScoped.class, true);
         assertContextActive(SessionScoped.class, true);
         assertContextActive(ApplicationScoped.class, true);
@@ -70,7 +69,7 @@ public class PushWithoutManagedExecutorTest extends AbstractCdiTest {
     @Test
     public void wsNoXhrBackgroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket");
-        click(ManagedExecutorPushComponent.RUN_BACKGROUND);
+        click(PushComponent.RUN_BACKGROUND);
         waitForPush();
         assertAllExceptRequestAndSessionActive();
     }
@@ -78,7 +77,7 @@ public class PushWithoutManagedExecutorTest extends AbstractCdiTest {
     @Test
     public void wsNoXhrForegroundRequestAndSessionDoesNotActive() {
         getDriver().get(getTestURL() + "websocket");
-        click(ManagedExecutorPushComponent.RUN_FOREGROUND);
+        click(PushComponent.RUN_FOREGROUND);
         assertAllExceptRequestAndSessionActive();
     }
 

--- a/vaadin-cdi-itest/src/test/resources/arquillian.xml
+++ b/vaadin-cdi-itest/src/test/resources/arquillian.xml
@@ -22,7 +22,25 @@
 
     <engine>
         <property name="deploymentExportPath">target/deployment</property>
+
     </engine>
+
+    <container qualifier="tomcat-weld">
+        <configuration>
+            <property name="catalinaHome">${catalina.home}</property>
+            <property name="user">deployer</property>
+            <property name="pass">deployer</property>
+            <property name="javaVmArguments">
+                --add-opens=java.base/java.io=ALL-UNNAMED
+                --add-opens=java.base/java.lang=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
+                --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
+                --add-opens=java.base/java.net=ALL-UNNAMED
+            </property>
+        </configuration>
+    </container>
 
     <container qualifier="tomee-debug">
         <configuration>

--- a/vaadin-cdi-itest/src/test/resources/tomcat/tomcat-users.xml
+++ b/vaadin-cdi-itest/src/test/resources/tomcat/tomcat-users.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<!--
+  By default, no user is included in the "manager-gui" role required
+  to operate the "/manager/html" web application.  If you wish to use this app,
+  you must define such a user - the username and password are arbitrary.
+
+  Built-in Tomcat manager roles:
+    - manager-gui    - allows access to the HTML GUI and the status pages
+    - manager-script - allows access to the HTTP API and the status pages
+    - manager-jmx    - allows access to the JMX proxy and the status pages
+    - manager-status - allows access to the status pages only
+
+  The users below are wrapped in a comment and are therefore ignored. If you
+  wish to configure one or more of these users for use with the manager web
+  application, do not forget to remove the <!.. ..> that surrounds them. You
+  will also need to set the passwords to something appropriate.
+-->
+  <user username="deployer" password="deployer" roles="manager-script"/>
+  <user username="admin" password="admin" roles="manager-gui"/>
+    <!--
+      <user username="robot" password="<must-be-changed>" roles="manager-script"/>
+    -->
+<!--
+  The sample user and role entries below are intended for use with the
+  examples web application. They are wrapped in a comment and thus are ignored
+  when reading this file. If you wish to configure these users for use with the
+  examples web application, do not forget to remove the <!.. ..> that surrounds
+  them. You will also need to set the passwords to something appropriate.
+-->
+<!--
+  <role rolename="tomcat"/>
+  <role rolename="role1"/>
+  <user username="tomcat" password="<must-be-changed>" roles="tomcat"/>
+  <user username="both" password="<must-be-changed>" roles="tomcat,role1"/>
+  <user username="role1" password="<must-be-changed>" roles="role1"/>
+-->
+</tomcat-users>

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceExecutorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiVaadinServletServiceExecutorTest.java
@@ -171,7 +171,7 @@ public class CdiVaadinServletServiceExecutorTest {
                     // Simulate @Resource injection without name or lookup into
                     // VaadinTaskExecutorSelector bean in weld mock environment
                     .bindResource(
-                            "java:comp/env/com.vaadin.cdi.VaadinTaskExecutorSelector/managedExecutor",
+                            "java:comp/env/com.vaadin.cdi.VaadinTaskExecutorSelector$FromResource/managedExecutor",
                             managedExecutorService);
         }
 


### PR DESCRIPTION
This change provides a solution for environments that aren't fully Jakarta EE
compliant (e.g., Tomcat with Weld) by implementing a runtime check for
ManagedExecutorService availability. This prevents deployment failures by:

1. Programmatically resolving the bean through CDI
2. Gracefully handling missing ManagedExecutorService in the classpath
3. Handling javax.naming.NameNotFoundException when JNDI lookup fails

The implementation allows for fallback to alternative execution strategies
when necessary, improving application resilience.

Also adds tests for non-CDI compliant environment scenarios.

Fixes #476