### PR TITLE
chore: upgrade WildFly to 39

### DIFF
--- a/vaadin-cdi-itest/pom.xml
+++ b/vaadin-cdi-itest/pom.xml
@@ -17,7 +17,7 @@
         <surefire.excludedGroups>com.vaadin.cdi.itest.SlowTests</surefire.excludedGroups>
         <apache-tomcat.version>11.0.8</apache-tomcat.version>
         <apache-tomee.version>10.1.0</apache-tomee.version>
-        <wildfly.version>38.0.0.Final</wildfly.version>
+        <wildfly.version>39.0.0.Final</wildfly.version>
         <openliberty.version>25.0.0.6</openliberty.version>
         <openliberty.template>jakartaee10</openliberty.template>
         <openliberty.runtimeArtifactGroupId>io.openliberty</openliberty.runtimeArtifactGroupId>

--- a/vaadin-cdi-itest/src/test/resources/wildfly/jboss-deployment-structure.xml
+++ b/vaadin-cdi-itest/src/test/resources/wildfly/jboss-deployment-structure.xml
@@ -15,9 +15,14 @@
   -->
 
 <jboss-deployment-structure>
+    <!--
+        This is required to avoid conflicts with WildFly's Jackson module
+        Affected Wildfly versions are 36, 37 and 38. Wildfly 39 ships Jackson
+        2.20 that is compatible with Vaadin 25
     <deployment>
         <exclusions>
             <module name="com.fasterxml.jackson.core.jackson-annotations"/>
         </exclusions>
     </deployment>
+    -->
 </jboss-deployment-structure>


### PR DESCRIPTION
WildFly 39 ships with Jackson 2.20 which is compatible with Vaadin 25, so the Jackson module exclusion workaround is no longer needed. The workaround is preserved but commented, as a reminder for potential future similar issues.
