### PR TITLE
Fix: #506 - VaadinSessionScopedContext was no longer active

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
@@ -43,7 +43,6 @@ import com.vaadin.cdi.context.VaadinSessionScopedContext;
 import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.cdi.util.DependentProvider;
-import com.vaadin.flow.server.ServiceInitEvent;
 
 /**
  * CDI Extension needed to register Vaadin scopes to the runtime.
@@ -67,11 +66,7 @@ public class VaadinExtension implements Extension {
         uiScopedContext = new UIScopedContext(beanManager);
         routeScopedContext = new RouteScopedContext(beanManager);
         addContext(afterBeanDiscovery, serviceScopedContext, null);
-        VaadinSessionScopedContext sessionScopedContext = new VaadinSessionScopedContext(beanManager);
-        afterBeanDiscovery.<ServiceInitEvent>addObserverMethod()
-            .observedType(ServiceInitEvent.class)
-            .notifyWith(instance -> sessionScopedContext.initializeActivationPolicy(instance.getEvent()));
-        addContext(afterBeanDiscovery,sessionScopedContext, null);
+        addContext(afterBeanDiscovery,new VaadinSessionScopedContext(beanManager), null);
         addContext(afterBeanDiscovery, uiScopedContext, NormalUIScoped.class);
         addContext(afterBeanDiscovery, routeScopedContext,
                 NormalRouteScoped.class);

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
@@ -35,8 +35,6 @@ import com.vaadin.cdi.DeploymentValidator.BeanInfo;
 import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.NormalUIScoped;
 import com.vaadin.cdi.annotation.VaadinServiceEnabled;
-import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
-import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.context.ContextWrapper;
 import com.vaadin.cdi.context.RouteScopedContext;
 import com.vaadin.cdi.context.UIScopedContext;
@@ -45,11 +43,7 @@ import com.vaadin.cdi.context.VaadinSessionScopedContext;
 import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.cdi.util.DependentProvider;
-import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
 
 /**
  * CDI Extension needed to register Vaadin scopes to the runtime.
@@ -61,10 +55,6 @@ public class VaadinExtension implements Extension {
     private RouteScopedContext routeScopedContext;
     private Set<BeanInfo> beanInfoSet = new HashSet<>();
 
-    /**
-     * The current VaadinSessionScopeActivationPolicy.
-     */
-    private static Policy vaadinSessionScopeActivationPolicy = VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 
     private void storeBeanValidationInfo(@Observes ProcessBean processBean) {
         beanInfoSet.add(new BeanInfo(processBean.getBean(),
@@ -74,53 +64,19 @@ public class VaadinExtension implements Extension {
     private void addContexts(@Observes AfterBeanDiscovery afterBeanDiscovery,
             BeanManager beanManager) {
         serviceScopedContext = new VaadinServiceScopedContext(beanManager);
-        afterBeanDiscovery.<ServiceInitEvent>addObserverMethod()
-            .observedType(ServiceInitEvent.class)
-            .notifyWith(instance -> this.onServiceInit(instance.getEvent()));
         uiScopedContext = new UIScopedContext(beanManager);
         routeScopedContext = new RouteScopedContext(beanManager);
         addContext(afterBeanDiscovery, serviceScopedContext, null);
-        addContext(afterBeanDiscovery,
-                new VaadinSessionScopedContext(beanManager), null);
+        VaadinSessionScopedContext sessionScopedContext = new VaadinSessionScopedContext(beanManager);
+        afterBeanDiscovery.<ServiceInitEvent>addObserverMethod()
+            .observedType(ServiceInitEvent.class)
+            .notifyWith(instance -> sessionScopedContext.initializeActivationPolicy(instance.getEvent()));
+        addContext(afterBeanDiscovery,sessionScopedContext, null);
         addContext(afterBeanDiscovery, uiScopedContext, NormalUIScoped.class);
         addContext(afterBeanDiscovery, routeScopedContext,
                 NormalRouteScoped.class);
     }
 
-    /**
-     * Called when the VaadinService is initialized.
-     * @param event the ServiceInitEvent
-     */
-    private void onServiceInit(final ServiceInitEvent event) {
-        vaadinSessionScopeActivationPolicy = this.determineVaadinSessionScopeActivationPolicy(event.getSource());
-    }
-
-    /**
-     * Determine the VaadinSessionScopeActivationPolicy for the current VaadinService.
-     * @param vaadinService the current VaadinService
-     * @return the determined policy
-     */
-    private Policy determineVaadinSessionScopeActivationPolicy(final VaadinService vaadinService) {
-        if (vaadinService == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final VaadinContext context = vaadinService.getContext();
-        if (context == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
-        if (registry == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
-        if (configurator == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
-            return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
-        }
-        return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-    }
 
     // Validate annotated executor
 
@@ -170,14 +126,6 @@ public class VaadinExtension implements Extension {
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger(VaadinExtension.class);
-    }
-
-    /**
-     * Get the current VaadinSessionScopeActivationPolicy.
-     * @return the current VaadinSessionScopeActivationPolicy
-     */
-    public static Policy getVaadinSessionScopeActivationPolicy() {
-        return vaadinSessionScopeActivationPolicy;
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
@@ -54,7 +54,6 @@ public class VaadinExtension implements Extension {
     private RouteScopedContext routeScopedContext;
     private Set<BeanInfo> beanInfoSet = new HashSet<>();
 
-
     private void storeBeanValidationInfo(@Observes ProcessBean processBean) {
         beanInfoSet.add(new BeanInfo(processBean.getBean(),
                 processBean.getAnnotated()));
@@ -66,12 +65,12 @@ public class VaadinExtension implements Extension {
         uiScopedContext = new UIScopedContext(beanManager);
         routeScopedContext = new RouteScopedContext(beanManager);
         addContext(afterBeanDiscovery, serviceScopedContext, null);
-        addContext(afterBeanDiscovery,new VaadinSessionScopedContext(beanManager), null);
+        addContext(afterBeanDiscovery,
+                new VaadinSessionScopedContext(beanManager), null);
         addContext(afterBeanDiscovery, uiScopedContext, NormalUIScoped.class);
         addContext(afterBeanDiscovery, routeScopedContext,
                 NormalRouteScoped.class);
     }
-
 
     // Validate annotated executor
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/VaadinExtension.java
@@ -35,6 +35,8 @@ import com.vaadin.cdi.DeploymentValidator.BeanInfo;
 import com.vaadin.cdi.annotation.NormalRouteScoped;
 import com.vaadin.cdi.annotation.NormalUIScoped;
 import com.vaadin.cdi.annotation.VaadinServiceEnabled;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.context.ContextWrapper;
 import com.vaadin.cdi.context.RouteScopedContext;
 import com.vaadin.cdi.context.UIScopedContext;
@@ -43,6 +45,11 @@ import com.vaadin.cdi.context.VaadinSessionScopedContext;
 import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.cdi.util.DependentProvider;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * CDI Extension needed to register Vaadin scopes to the runtime.
@@ -54,6 +61,11 @@ public class VaadinExtension implements Extension {
     private RouteScopedContext routeScopedContext;
     private Set<BeanInfo> beanInfoSet = new HashSet<>();
 
+    /**
+     * The current VaadinSessionScopeActivationPolicy.
+     */
+    private static Policy vaadinSessionScopeActivationPolicy = VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+
     private void storeBeanValidationInfo(@Observes ProcessBean processBean) {
         beanInfoSet.add(new BeanInfo(processBean.getBean(),
                 processBean.getAnnotated()));
@@ -62,6 +74,9 @@ public class VaadinExtension implements Extension {
     private void addContexts(@Observes AfterBeanDiscovery afterBeanDiscovery,
             BeanManager beanManager) {
         serviceScopedContext = new VaadinServiceScopedContext(beanManager);
+        afterBeanDiscovery.<ServiceInitEvent>addObserverMethod()
+            .observedType(ServiceInitEvent.class)
+            .notifyWith(instance -> this.onServiceInit(instance.getEvent()));
         uiScopedContext = new UIScopedContext(beanManager);
         routeScopedContext = new RouteScopedContext(beanManager);
         addContext(afterBeanDiscovery, serviceScopedContext, null);
@@ -70,6 +85,41 @@ public class VaadinExtension implements Extension {
         addContext(afterBeanDiscovery, uiScopedContext, NormalUIScoped.class);
         addContext(afterBeanDiscovery, routeScopedContext,
                 NormalRouteScoped.class);
+    }
+
+    /**
+     * Called when the VaadinService is initialized.
+     * @param event the ServiceInitEvent
+     */
+    private void onServiceInit(final ServiceInitEvent event) {
+        vaadinSessionScopeActivationPolicy = this.determineVaadinSessionScopeActivationPolicy(event.getSource());
+    }
+
+    /**
+     * Determine the VaadinSessionScopeActivationPolicy for the current VaadinService.
+     * @param vaadinService the current VaadinService
+     * @return the determined policy
+     */
+    private Policy determineVaadinSessionScopeActivationPolicy(final VaadinService vaadinService) {
+        if (vaadinService == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final VaadinContext context = vaadinService.getContext();
+        if (context == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        if (registry == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
+        if (configurator == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
+            return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
+        }
+        return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
     }
 
     // Validate annotated executor
@@ -120,6 +170,14 @@ public class VaadinExtension implements Extension {
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger(VaadinExtension.class);
+    }
+
+    /**
+     * Get the current VaadinSessionScopeActivationPolicy.
+     * @return the current VaadinSessionScopeActivationPolicy
+     */
+    public static Policy getVaadinSessionScopeActivationPolicy() {
+        return vaadinSessionScopeActivationPolicy;
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
@@ -5,18 +5,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to specify the activation policy for the VaadinSessionScopedContext.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface VaadinSessionScopeActivationPolicy {
 
 	/**
-	 * Default value for {@link #strict()}
+	 * Activation policies for the VaadinSessionScopedContext.
 	 */
-	boolean DEFAULT_STRICT = false;
+	enum Policy {
+		STRICT,
+		LENIENT
+	}
+
+	/**
+	 * Default policy for the VaadinSessionScopedContext.
+	 */
+	Policy DEFAULT_POLICY = Policy.LENIENT;
 
 	/**
 	 * Determines if the session scope should check the session lock to activate the Scope.
-	 * @return true if strict session locking should be enabled, false otherwise
+	 * @return Policy indicating the activation policy for VaadinSessionScoped beans
 	 */
-	boolean strict() default DEFAULT_STRICT;
+	Policy value() default Policy.LENIENT;
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
@@ -1,0 +1,22 @@
+package com.vaadin.cdi.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface VaadinSessionScopeActivationPolicy {
+
+	/**
+	 * Default value for {@link #strict()}
+	 */
+	boolean DEFAULT_STRICT = false;
+
+	/**
+	 * Determines if the session scope should check the session lock to activate the Scope.
+	 * @return true if strict session locking should be enabled, false otherwise
+	 */
+	boolean strict() default DEFAULT_STRICT;
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
@@ -14,14 +14,14 @@ import com.vaadin.flow.server.VaadinSession;
  * {@link VaadinSessionScopedContext}.
  * <p>
  * Place this annotation on your {@link AppShellConfigurator}
- * implementation to control whether the {@code VaadinSessionScoped} context requires
+ * implementation to control whether {@link VaadinSessionScoped} context requires
  * the current {@link VaadinSession} to be locked to
  * be considered active.
  * <ul>
  *     <li>{@link Policy#LENIENT} (default) – context is active as long as a
- *         {@code VaadinSession} is available on the current thread, regardless of
+ *         {@link VaadinSession} is available on the current thread, regardless of
  *         whether the session is locked.</li>
- *     <li>{@link Policy#STRICT} – context is active only if a {@code VaadinSession}
+ *     <li>{@link Policy#STRICT} – context is active only if a {@link VaadinSession}
  *         is available <em>and</em> currently locked by the calling thread.</li>
  * </ul>
  *

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
@@ -5,8 +5,35 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.vaadin.cdi.context.VaadinSessionScopedContext;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.VaadinSession;
+
 /**
- * Annotation to specify the activation policy for the VaadinSessionScopedContext.
+ * Annotation to specify the activation policy for the
+ * {@link VaadinSessionScopedContext}.
+ * <p>
+ * Place this annotation on your {@link AppShellConfigurator}
+ * implementation to control whether the {@code VaadinSessionScoped} context requires
+ * the current {@link VaadinSession} to be locked to
+ * be considered active.
+ * <ul>
+ *     <li>{@link Policy#LENIENT} (default) – context is active as long as a
+ *         {@code VaadinSession} is available on the current thread, regardless of
+ *         whether the session is locked.</li>
+ *     <li>{@link Policy#STRICT} – context is active only if a {@code VaadinSession}
+ *         is available <em>and</em> currently locked by the calling thread.</li>
+ * </ul>
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * @VaadinSessionScopeActivationPolicy(Policy.STRICT)
+ * public class AppShell implements AppShellConfigurator {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * If the annotation is not present, {@link #DEFAULT_POLICY} is used.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/annotation/VaadinSessionScopeActivationPolicy.java
@@ -43,7 +43,13 @@ public @interface VaadinSessionScopeActivationPolicy {
 	 * Activation policies for the VaadinSessionScopedContext.
 	 */
 	enum Policy {
+		/**
+		 * Context is active only if a {@link VaadinSession} is available <em>and</em> currently locked by the calling thread.
+		 */
 		STRICT,
+		/**
+		 * Context is active as long as a {@link VaadinSession} is available on the current thread, regardless of whether the session is locked.
+		 */
 		LENIENT
 	}
 

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -23,13 +23,18 @@ import java.util.concurrent.atomic.AtomicReference;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.BeanManager;
 
-import com.vaadin.cdi.VaadinExtension;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
 import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.util.ContextUtils;
 import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.ContextualStorage;
 
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -43,6 +48,11 @@ import com.vaadin.flow.server.VaadinSession;
 public class VaadinSessionScopedContext extends AbstractContext {
     private final BeanManager beanManager;
     private static final String ATTRIBUTE_NAME = VaadinSessionScopedContext.class.getName();
+
+    /**
+     * The current VaadinSessionScopeActivationPolicy.
+     */
+    private static final AtomicReference<Policy> activationPolicy = new AtomicReference<>(null);
 
     public VaadinSessionScopedContext(BeanManager beanManager) {
         super(beanManager);
@@ -106,11 +116,49 @@ public class VaadinSessionScopedContext extends AbstractContext {
     @Override
     public boolean isActive() {
         final VaadinSession session = VaadinSession.getCurrent();
-        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinExtension.getVaadinSessionScopeActivationPolicy());
+        if (VaadinSessionScopedContext.getActivationPolicy() == null && session != null) {
+            activationPolicy.compareAndSet(null, determineVaadinSessionScopeActivationPolicy(session.getService()));
+        }
+        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinSessionScopedContext.getActivationPolicy());
         if (isStrict) {
             return session != null && session.hasLock();
         }
         return session != null;
+    }
+
+    /**
+     * Initialize the VaadinSessionScopeActivationPolicy. Ensures the Operation is done exactly once.
+     * @param initEvent the ServiceInitEvent containing the current VaadinService.
+     */
+    public void initializeActivationPolicy(final ServiceInitEvent initEvent) {
+        activationPolicy.compareAndSet(null, determineVaadinSessionScopeActivationPolicy(initEvent.getSource()));
+    }
+
+    /**
+     * Determine the VaadinSessionScopeActivationPolicy for the current VaadinService.
+     * @param vaadinService the current VaadinService
+     * @return the determined policy
+     */
+    private Policy determineVaadinSessionScopeActivationPolicy(final VaadinService vaadinService) {
+        if (vaadinService == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final VaadinContext context = vaadinService.getContext();
+        if (context == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        if (registry == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
+        if (configurator == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        }
+        if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
+            return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
+        }
+        return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
     }
 
 
@@ -135,6 +183,14 @@ public class VaadinSessionScopedContext extends AbstractContext {
         // except we get here after the application is undeployed.
         return (VaadinSession.getCurrent() != null
                 && !ContextUtils.isContextActive(VaadinSessionScoped.class));
+    }
+
+    /**
+     * Get the current VaadinSessionScopeActivationPolicy.
+     * @return the current policy
+     */
+    public static Policy getActivationPolicy() {
+        return activationPolicy.get();
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -50,14 +50,29 @@ public class VaadinSessionScopedContext extends AbstractContext {
         VaadinSession session = VaadinSession.getCurrent();
         ContextualStorage storage = findContextualStorage(session);
         if (storage == null && createIfNotExist) {
-            storage = new ContextualStorage(beanManager, false, true);
-            session.setAttribute(ATTRIBUTE_NAME, storage);
+            storage = initializeContextualStorage(beanManager, session);
         }
         return storage;
     }
 
     private static ContextualStorage findContextualStorage(VaadinSession session) {
         return getContextualStorage(session);
+    }
+
+    /**
+     * Initializes the contextual storage for the given session. Handles locking internally.
+     * @param beanManager the bean manager
+     * @param session the concerned session
+     * @return the initialized contextual storage
+     */
+    private static ContextualStorage initializeContextualStorage(final BeanManager beanManager, final VaadinSession session) {
+        final ContextualStorage storage = new ContextualStorage(beanManager, false, true);
+        if (session.hasLock()) {
+            session.setAttribute(ATTRIBUTE_NAME, storage);
+        } else {
+            session.accessSynchronously(() -> session.setAttribute(ATTRIBUTE_NAME, storage));
+        }
+        return storage;
     }
 
     /**

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -17,8 +17,14 @@
 package com.vaadin.cdi.context;
 
 import java.lang.annotation.Annotation;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.BeanManager;
 import com.vaadin.cdi.util.ContextUtils;
@@ -39,6 +45,8 @@ import com.vaadin.flow.server.VaadinSession;
 public class VaadinSessionScopedContext extends AbstractContext {
     private final BeanManager beanManager;
     private static final String ATTRIBUTE_NAME = VaadinSessionScopedContext.class.getName();
+    private static final AtomicBoolean STRICT_VALIDATION_INITIALIZED = new AtomicBoolean(false);
+    private static boolean useStrictValidation = VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
 
     public VaadinSessionScopedContext(BeanManager beanManager) {
         super(beanManager);
@@ -97,8 +105,49 @@ public class VaadinSessionScopedContext extends AbstractContext {
 
     @Override
     public boolean isActive() {
-        VaadinSession session = VaadinSession.getCurrent();
+        final VaadinSession session = VaadinSession.getCurrent();
+        final boolean isStrict = this.shouldUseStrictChecks(session);
+        if (isStrict) {
+            return session != null && session.hasLock();
+        }
         return session != null;
+    }
+
+
+    /**
+     * Retrieves the VaadinSessionScopeActivationPolicy from the AppShell and Caches it.
+     * @param session the current VaadinSession
+     * @return true if strict validation is enabled, false otherwise.
+     */
+    private boolean shouldUseStrictChecks(final VaadinSession session) {
+        if (STRICT_VALIDATION_INITIALIZED.get()) {
+            return useStrictValidation;
+        }
+        if (session == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+        }
+        final VaadinService service = session.getService();
+        if (service == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+        }
+        final VaadinContext context = service.getContext();
+        if (context == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+        }
+        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        if (registry == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+        }
+        if (STRICT_VALIDATION_INITIALIZED.compareAndSet(false, true)) {
+            final Class<? extends AppShellConfigurator> configurator = registry.getShell();
+            if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
+                final VaadinSessionScopeActivationPolicy policy = configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class);
+                useStrictValidation = policy.strict();
+            } else {
+                useStrictValidation = VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+            }
+        }
+        return useStrictValidation;
     }
 
     public static void destroy(VaadinSession session) {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -17,6 +17,7 @@
 package com.vaadin.cdi.context;
 
 import java.lang.annotation.Annotation;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.BeanManager;
@@ -56,8 +57,22 @@ public class VaadinSessionScopedContext extends AbstractContext {
     }
 
     private static ContextualStorage findContextualStorage(VaadinSession session) {
-        // session lock is checked inside
-        return (ContextualStorage) session.getAttribute(ATTRIBUTE_NAME);
+        return getContextualStorage(session);
+    }
+
+    /**
+     * Retrieves the contextual storage from the session. Handles locking internally.
+     * @param session the concerned session
+     * @return the contextual storage
+     */
+    private static ContextualStorage getContextualStorage(final VaadinSession session) {
+        final AtomicReference<ContextualStorage> result = new AtomicReference<>();
+        if (session.hasLock()) {
+            result.set((ContextualStorage) session.getAttribute(ATTRIBUTE_NAME));
+        } else {
+            session.accessSynchronously(() -> result.set((ContextualStorage) session.getAttribute(ATTRIBUTE_NAME)));
+        }
+        return result.get();
     }
 
     @Override
@@ -68,7 +83,7 @@ public class VaadinSessionScopedContext extends AbstractContext {
     @Override
     public boolean isActive() {
         VaadinSession session = VaadinSession.getCurrent();
-        return session != null && session.hasLock();
+        return session != null;
     }
 
     public static void destroy(VaadinSession session) {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -138,8 +138,11 @@ public class VaadinSessionScopedContext extends AbstractContext {
         if (registry == null) {
             return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
         }
+        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
+        if (configurator == null) {
+            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
+        }
         if (STRICT_VALIDATION_INITIALIZED.compareAndSet(false, true)) {
-            final Class<? extends AppShellConfigurator> configurator = registry.getShell();
             if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
                 final VaadinSessionScopeActivationPolicy policy = configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class);
                 useStrictValidation = policy.strict();

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -30,11 +30,7 @@ import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.ContextualStorage;
 
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
-import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.server.AppShellRegistry;
-import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
+import com.vaadin.cdi.util.VaadinSessionActivationPolicyHolder;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -48,11 +44,6 @@ import com.vaadin.flow.server.VaadinSession;
 public class VaadinSessionScopedContext extends AbstractContext {
     private final BeanManager beanManager;
     private static final String ATTRIBUTE_NAME = VaadinSessionScopedContext.class.getName();
-
-    /**
-     * The current VaadinSessionScopeActivationPolicy.
-     */
-    private static final AtomicReference<Policy> activationPolicy = new AtomicReference<>(null);
 
     public VaadinSessionScopedContext(BeanManager beanManager) {
         super(beanManager);
@@ -116,49 +107,11 @@ public class VaadinSessionScopedContext extends AbstractContext {
     @Override
     public boolean isActive() {
         final VaadinSession session = VaadinSession.getCurrent();
-        if (VaadinSessionScopedContext.getActivationPolicy() == null && session != null) {
-            activationPolicy.compareAndSet(null, determineVaadinSessionScopeActivationPolicy(session.getService()));
-        }
-        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinSessionScopedContext.getActivationPolicy());
+        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinSessionScopedContext.getActivationPolicy(session));
         if (isStrict) {
             return session != null && session.hasLock();
         }
         return session != null;
-    }
-
-    /**
-     * Initialize the VaadinSessionScopeActivationPolicy. Ensures the Operation is done exactly once.
-     * @param initEvent the ServiceInitEvent containing the current VaadinService.
-     */
-    public void initializeActivationPolicy(final ServiceInitEvent initEvent) {
-        activationPolicy.compareAndSet(null, determineVaadinSessionScopeActivationPolicy(initEvent.getSource()));
-    }
-
-    /**
-     * Determine the VaadinSessionScopeActivationPolicy for the current VaadinService.
-     * @param vaadinService the current VaadinService
-     * @return the determined policy
-     */
-    private Policy determineVaadinSessionScopeActivationPolicy(final VaadinService vaadinService) {
-        if (vaadinService == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final VaadinContext context = vaadinService.getContext();
-        if (context == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
-        if (registry == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
-        if (configurator == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        }
-        if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
-            return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
-        }
-        return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
     }
 
 
@@ -186,11 +139,18 @@ public class VaadinSessionScopedContext extends AbstractContext {
     }
 
     /**
-     * Get the current VaadinSessionScopeActivationPolicy.
-     * @return the current policy
+     * Returns the current activation policy.
+     * @param session the current session, or null if there is no current session
+     * @return the current activation policy
      */
-    public static Policy getActivationPolicy() {
-        return activationPolicy.get();
+    public static Policy getActivationPolicy(final VaadinSession session) {
+        final Policy policy;
+        if (session == null) {
+            policy = VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+        } else {
+            policy = VaadinSessionActivationPolicyHolder.get(session);
+        }
+        return policy;
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -17,16 +17,14 @@
 package com.vaadin.cdi.context;
 
 import java.lang.annotation.Annotation;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
-import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.server.AppShellRegistry;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.BeanManager;
+
+import com.vaadin.cdi.VaadinExtension;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.util.ContextUtils;
 import com.vaadin.cdi.util.AbstractContext;
 import com.vaadin.cdi.util.ContextualStorage;
@@ -45,8 +43,6 @@ import com.vaadin.flow.server.VaadinSession;
 public class VaadinSessionScopedContext extends AbstractContext {
     private final BeanManager beanManager;
     private static final String ATTRIBUTE_NAME = VaadinSessionScopedContext.class.getName();
-    private static final AtomicBoolean STRICT_VALIDATION_INITIALIZED = new AtomicBoolean(false);
-    private static boolean useStrictValidation = VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
 
     public VaadinSessionScopedContext(BeanManager beanManager) {
         super(beanManager);
@@ -103,55 +99,20 @@ public class VaadinSessionScopedContext extends AbstractContext {
         return VaadinSessionScoped.class;
     }
 
+    /**
+     * Determines if the context is active based on the current session and activation policy.
+     * @return true if the context is active, false otherwise
+     */
     @Override
     public boolean isActive() {
         final VaadinSession session = VaadinSession.getCurrent();
-        final boolean isStrict = this.shouldUseStrictChecks(session);
+        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinExtension.getVaadinSessionScopeActivationPolicy());
         if (isStrict) {
             return session != null && session.hasLock();
         }
         return session != null;
     }
 
-
-    /**
-     * Retrieves the VaadinSessionScopeActivationPolicy from the AppShell and Caches it.
-     * @param session the current VaadinSession
-     * @return true if strict validation is enabled, false otherwise.
-     */
-    private boolean shouldUseStrictChecks(final VaadinSession session) {
-        if (STRICT_VALIDATION_INITIALIZED.get()) {
-            return useStrictValidation;
-        }
-        if (session == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-        }
-        final VaadinService service = session.getService();
-        if (service == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-        }
-        final VaadinContext context = service.getContext();
-        if (context == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-        }
-        final AppShellRegistry registry = AppShellRegistry.getInstance(context);
-        if (registry == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-        }
-        final Class<? extends AppShellConfigurator> configurator = registry.getShell();
-        if (configurator == null) {
-            return VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-        }
-        if (STRICT_VALIDATION_INITIALIZED.compareAndSet(false, true)) {
-            if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
-                final VaadinSessionScopeActivationPolicy policy = configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class);
-                useStrictValidation = policy.strict();
-            } else {
-                useStrictValidation = VaadinSessionScopeActivationPolicy.DEFAULT_STRICT;
-            }
-        }
-        return useStrictValidation;
-    }
 
     public static void destroy(VaadinSession session) {
         ContextualStorage storage = findContextualStorage(session);

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/VaadinSessionScopedContext.java
@@ -107,7 +107,7 @@ public class VaadinSessionScopedContext extends AbstractContext {
     @Override
     public boolean isActive() {
         final VaadinSession session = VaadinSession.getCurrent();
-        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinSessionScopedContext.getActivationPolicy(session));
+        final boolean isStrict = Objects.equals(Policy.STRICT, VaadinSessionActivationPolicyHolder.get(session));
         if (isStrict) {
             return session != null && session.hasLock();
         }
@@ -136,21 +136,6 @@ public class VaadinSessionScopedContext extends AbstractContext {
         // except we get here after the application is undeployed.
         return (VaadinSession.getCurrent() != null
                 && !ContextUtils.isContextActive(VaadinSessionScoped.class));
-    }
-
-    /**
-     * Returns the current activation policy.
-     * @param session the current session, or null if there is no current session
-     * @return the current activation policy
-     */
-    public static Policy getActivationPolicy(final VaadinSession session) {
-        final Policy policy;
-        if (session == null) {
-            policy = VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-        } else {
-            policy = VaadinSessionActivationPolicyHolder.get(session);
-        }
-        return policy;
     }
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
@@ -83,9 +83,6 @@ public class VaadinSessionActivationPolicyHolder {
 	 * @return the determined policy
 	 */
 	private static Policy determinePolicy(final VaadinService vaadinService) {
-		if (vaadinService == null) {
-			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-		}
 		final VaadinContext context = vaadinService.getContext();
 		if (context == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
@@ -1,0 +1,120 @@
+package com.vaadin.cdi.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Utility class to get the VaadinSessionScopeActivationPolicy for the current VaadinService.
+ */
+public class VaadinSessionActivationPolicyHolder {
+
+	/**
+	 * Get the VaadinSessionScopeActivationPolicy for the current VaadinService.
+	 * @param vaadinService the current VaadinService
+	 * @return the determined policy
+	 */
+	public static Policy get(final VaadinService vaadinService) {
+		if (vaadinService == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		final VaadinContext context = vaadinService.getContext();
+		if (context == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		final PolicyWrapper attribute = context.getAttribute(PolicyWrapper.class, () -> new PolicyWrapper(determinePolicy(vaadinService)));
+		return attribute.policy;
+	}
+
+	/**
+	 * Get the VaadinSessionScopeActivationPolicy for the current VaadinSession.
+	 * @param session the current VaadinSession
+	 * @return the determined policy
+	 */
+	public static Policy get(final VaadinSession session) {
+		if (session == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		PolicyWrapper wrapper = ensureLock(session, () -> session.getAttribute(PolicyWrapper.class));
+		if (wrapper == null) {
+			// We can do some performance optimization...
+			final Policy policy = get(session.getService());
+			wrapper = new PolicyWrapper(policy);
+			final PolicyWrapper finalWrapper = wrapper;
+			ensureLock(session, () -> session.setAttribute(PolicyWrapper.class, finalWrapper));
+		}
+		return wrapper.policy;
+	}
+
+	/**
+	 * Ensures that the session has a lock before executing the supplier.
+	 * @param session the session
+	 * @param supplier the supplier
+	 * @return the result of the supplier
+	 * @param <T> the type of the result
+	 */
+	private static <T> T ensureLock(final VaadinSession session, final Supplier<T> supplier) {
+		if (session.hasLock()) {
+			return supplier.get();
+		} else {
+			final AtomicReference<T> result = new AtomicReference<>();
+			session.accessSynchronously(() -> result.set(supplier.get()));
+			return result.get();
+		}
+	}
+
+	/**
+	 * Ensures that the session has a lock before executing the runnable.
+	 * @param session the session
+	 * @param runnable the runnable
+	 */
+	private static void ensureLock(final VaadinSession session, final Runnable runnable) {
+		if (session.hasLock()) {
+			runnable.run();
+		} else {
+			session.accessSynchronously(runnable::run);
+		}
+	}
+
+	/**
+	 * Determine the VaadinSessionScopeActivationPolicy for the current VaadinService.
+	 * @param vaadinService the current VaadinService
+	 * @return the determined policy
+	 */
+	private static Policy determinePolicy(final VaadinService vaadinService) {
+		if (vaadinService == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		final VaadinContext context = vaadinService.getContext();
+		if (context == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		final AppShellRegistry registry = AppShellRegistry.getInstance(context);
+		if (registry == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		final Class<? extends AppShellConfigurator> configurator = registry.getShell();
+		if (configurator == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		if (configurator.isAnnotationPresent(VaadinSessionScopeActivationPolicy.class)) {
+			return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
+		}
+		return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+	}
+
+	/**
+	 * Wrapper for the VaadinSessionScopeActivationPolicy.
+	 * @param policy the policy
+	 */
+	private record PolicyWrapper(Policy policy) {
+	}
+
+}

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
@@ -1,5 +1,6 @@
 package com.vaadin.cdi.util;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -17,6 +18,11 @@ import com.vaadin.flow.server.VaadinSession;
 public class VaadinSessionActivationPolicyHolder {
 
 	/**
+	 * Caches the Policies for each VaadinService.
+	 */
+	private static final ConcurrentHashMap<String, PolicyWrapper> policyCache = new ConcurrentHashMap<>();
+
+	/**
 	 * Get the VaadinSessionScopeActivationPolicy for the current VaadinService.
 	 * @param vaadinService the current VaadinService
 	 * @return the determined policy
@@ -25,12 +31,8 @@ public class VaadinSessionActivationPolicyHolder {
 		if (vaadinService == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		final VaadinContext context = vaadinService.getContext();
-		if (context == null) {
-			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-		}
-		final PolicyWrapper attribute = context.getAttribute(PolicyWrapper.class, () -> new PolicyWrapper(determinePolicy(vaadinService)));
-		return attribute.policy;
+		final PolicyWrapper wrapper = policyCache.computeIfAbsent(vaadinService.getServiceName(), s -> initializePolicy(vaadinService));
+		return wrapper.policy;
 	}
 
 	/**
@@ -42,45 +44,12 @@ public class VaadinSessionActivationPolicyHolder {
 		if (session == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		PolicyWrapper wrapper = ensureLock(session, () -> session.getAttribute(PolicyWrapper.class));
-		if (wrapper == null) {
-			// We can do some performance optimization...
-			final Policy policy = get(session.getService());
-			wrapper = new PolicyWrapper(policy);
-			final PolicyWrapper finalWrapper = wrapper;
-			ensureLock(session, () -> session.setAttribute(PolicyWrapper.class, finalWrapper));
-		}
-		return wrapper.policy;
+		return get(session.getService());
 	}
 
-	/**
-	 * Ensures that the session has a lock before executing the supplier.
-	 * @param session the session
-	 * @param supplier the supplier
-	 * @return the result of the supplier
-	 * @param <T> the type of the result
-	 */
-	private static <T> T ensureLock(final VaadinSession session, final Supplier<T> supplier) {
-		if (session.hasLock()) {
-			return supplier.get();
-		} else {
-			final AtomicReference<T> result = new AtomicReference<>();
-			session.accessSynchronously(() -> result.set(supplier.get()));
-			return result.get();
-		}
-	}
-
-	/**
-	 * Ensures that the session has a lock before executing the runnable.
-	 * @param session the session
-	 * @param runnable the runnable
-	 */
-	private static void ensureLock(final VaadinSession session, final Runnable runnable) {
-		if (session.hasLock()) {
-			runnable.run();
-		} else {
-			session.accessSynchronously(runnable::run);
-		}
+	private static PolicyWrapper initializePolicy(final VaadinService vaadinService) {
+		vaadinService.addServiceDestroyListener(event -> policyCache.remove(vaadinService.getServiceName()));
+		return new PolicyWrapper(determinePolicy(vaadinService));
 	}
 
 	/**

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
@@ -7,20 +7,17 @@ import java.util.function.Supplier;
 import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy;
 import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.server.AppShellRegistry;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.*;
 
 /**
- * Utility class to get the VaadinSessionScopeActivationPolicy for the current VaadinService.
+ * Utility class to get the VaadinSessionScopeActivationPolicy for a VaadinService.
  */
 public class VaadinSessionActivationPolicyHolder {
 
 	/**
 	 * Caches the Policies for each VaadinService.
 	 */
-	private static final ConcurrentHashMap<String, PolicyWrapper> policyCache = new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<String, Policy> policyCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Get the VaadinSessionScopeActivationPolicy for the current VaadinService.
@@ -31,8 +28,11 @@ public class VaadinSessionActivationPolicyHolder {
 		if (vaadinService == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		final PolicyWrapper wrapper = policyCache.computeIfAbsent(vaadinService.getServiceName(), s -> initializePolicy(vaadinService));
-		return wrapper.policy;
+		final String servletName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
+		if (servletName == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		return policyCache.computeIfAbsent(servletName, s -> initializePolicy(vaadinService));
 	}
 
 	/**
@@ -47,9 +47,34 @@ public class VaadinSessionActivationPolicyHolder {
 		return get(session.getService());
 	}
 
-	private static PolicyWrapper initializePolicy(final VaadinService vaadinService) {
-		vaadinService.addServiceDestroyListener(event -> policyCache.remove(vaadinService.getServiceName()));
-		return new PolicyWrapper(determinePolicy(vaadinService));
+
+	/**
+	 * Initialize the policy for the given VaadinService.
+	 * @param vaadinService the VaadinService to initialize the policy for
+	 * @return the policy
+	 */
+	private static Policy initializePolicy(final VaadinService vaadinService) {
+		final String servletName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
+		if (servletName == null) {
+			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
+		}
+		vaadinService.addServiceDestroyListener(event -> policyCache.remove(servletName));
+		return determinePolicy(vaadinService);
+	}
+
+
+	/**
+	 * Check if the VaadinService is initialized.
+	 * @param vaadinService the VaadinService to check
+	 * @return true if the VaadinService is initialized, false otherwise
+	 */
+	private static boolean isServiceInitialized(final VaadinService vaadinService) {
+		if (vaadinService instanceof final VaadinServletService servletService) {
+			final VaadinServlet servlet = servletService.getServlet();
+			return servlet.getServletConfig() != null;
+		} else {
+			return false;
+		}
 	}
 
 	/**
@@ -77,13 +102,6 @@ public class VaadinSessionActivationPolicyHolder {
 			return configurator.getAnnotation(VaadinSessionScopeActivationPolicy.class).value();
 		}
 		return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
-	}
-
-	/**
-	 * Wrapper for the VaadinSessionScopeActivationPolicy.
-	 * @param policy the policy
-	 */
-	private record PolicyWrapper(Policy policy) {
 	}
 
 }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/util/VaadinSessionActivationPolicyHolder.java
@@ -28,11 +28,11 @@ public class VaadinSessionActivationPolicyHolder {
 		if (vaadinService == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		final String servletName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
-		if (servletName == null) {
+		final String serviceName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
+		if (serviceName == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		return policyCache.computeIfAbsent(servletName, s -> initializePolicy(vaadinService));
+		return policyCache.computeIfAbsent(serviceName, s -> initializePolicy(vaadinService));
 	}
 
 	/**
@@ -54,11 +54,11 @@ public class VaadinSessionActivationPolicyHolder {
 	 * @return the policy
 	 */
 	private static Policy initializePolicy(final VaadinService vaadinService) {
-		final String servletName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
-		if (servletName == null) {
+		final String serviceName = isServiceInitialized(vaadinService) ? vaadinService.getServiceName() : null;
+		if (serviceName == null) {
 			return VaadinSessionScopeActivationPolicy.DEFAULT_POLICY;
 		}
-		vaadinService.addServiceDestroyListener(event -> policyCache.remove(servletName));
+		vaadinService.addServiceDestroyListener(event -> policyCache.remove(serviceName));
 		return determinePolicy(vaadinService);
 	}
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -56,7 +56,7 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
     @Test
     public void get_context_withStrictPolicy_contextNotActive() {
         try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(Policy.STRICT);
+            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(Policy.STRICT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 
@@ -81,7 +81,7 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
     @Test
     public void get_context_withLenientPolicy() {
         try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(Policy.LENIENT);
+            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(Policy.LENIENT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 
@@ -111,7 +111,7 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
     public void get_context_withLockAndPolicy(boolean hasLock, Policy policy) {
         try (final MockedStatic<VaadinSessionScopedContext> mockedExtension =
             Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(policy);
+            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(policy);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
             final VaadinSession session = context.getSession();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -16,11 +16,10 @@
 
 package com.vaadin.cdi.context;
 
-import jakarta.enterprise.context.ContextNotActiveException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
@@ -56,9 +55,9 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
                 new VaadinSessionScopedContext(weld.select().select(
                         jakarta.enterprise.inject.spi.BeanManager.class).get());
 
-        assertFalse(sessionContext.isActive());
+        assertTrue(sessionContext.isActive());
 
-        assertThrows(ContextNotActiveException.class, () -> {
+        assertDoesNotThrow(() -> {
             SessionScopedTestBean ref =
                     BeanProvider.getContextualReference(SessionScopedTestBean.class);
             ref.getState();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import jakarta.enterprise.context.ContextNotActiveException;
 
-import com.vaadin.cdi.VaadinExtension;
 import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.cdi.util.BeanProvider;
@@ -53,8 +52,8 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
 
     @Test
     public void get_context_withStrictPolicy_contextNotActive() {
-        try (final MockedStatic<VaadinExtension> mockedExtension = Mockito.mockStatic(VaadinExtension.class)) {
-            mockedExtension.when(VaadinExtension::getVaadinSessionScopeActivationPolicy).thenReturn(Policy.STRICT);
+        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(Policy.STRICT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 
@@ -78,8 +77,8 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
 
     @Test
     public void get_context_withLenientPolicy() {
-        try (final MockedStatic<VaadinExtension> mockedExtension = Mockito.mockStatic(VaadinExtension.class)) {
-            mockedExtension.when(VaadinExtension::getVaadinSessionScopeActivationPolicy).thenReturn(Policy.LENIENT);
+        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(Policy.LENIENT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -17,6 +17,8 @@
 package com.vaadin.cdi.context;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -31,6 +33,7 @@ import jakarta.enterprise.context.ContextNotActiveException;
 import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.cdi.util.BeanProvider;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinSession;
 
 public class SessionContextTest extends AbstractContextTest<SessionContextTest.SessionScopedTestBean> {
@@ -98,6 +101,39 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
             });
         }
     }
+
+    @ParameterizedTest(name = "CDI-Locking-Test [hasLock={0}, policy={1}]")
+    @CsvSource({
+        "true,  LENIENT",
+        "false, LENIENT",
+        "true,  STRICT"
+    })
+    public void get_context_withLockAndLenientPolicy(boolean hasLock, Policy policy) {
+        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension =
+            Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(policy);
+            final SessionUnderTestContext context = new SessionUnderTestContext();
+            context.activate();
+            final VaadinSession session = context.getSession();
+            when(session.hasLock()).thenReturn(hasLock);
+
+            final VaadinSessionScopedContext sessionContext =
+                new VaadinSessionScopedContext(weld.select().select(
+                    jakarta.enterprise.inject.spi.BeanManager.class).get());
+            assertTrue(sessionContext.isActive());
+            assertDoesNotThrow(() -> {
+                SessionScopedTestBean ref =
+                    BeanProvider.getContextualReference(SessionScopedTestBean.class);
+                ref.getState();
+            });
+            if (hasLock) {
+                Mockito.verify(session, Mockito.never()).accessSynchronously(Mockito.any(Command.class));
+            } else {
+                Mockito.verify(session, Mockito.atLeastOnce()).accessSynchronously(Mockito.any(Command.class));
+            }
+        }
+    }
+
 
     @VaadinSessionScoped
     public static class SessionScopedTestBean extends TestBean {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.cdi.context;
 
+import com.vaadin.cdi.util.VaadinSessionActivationPolicyHolder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -55,8 +56,8 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
 
     @Test
     public void get_context_withStrictPolicy_contextNotActive() {
-        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(Policy.STRICT);
+        try (final MockedStatic<VaadinSessionActivationPolicyHolder> mockedExtension = Mockito.mockStatic(VaadinSessionActivationPolicyHolder.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(() -> VaadinSessionActivationPolicyHolder.get(Mockito.any(VaadinSession.class))).thenReturn(Policy.STRICT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 
@@ -80,8 +81,8 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
 
     @Test
     public void get_context_withLenientPolicy() {
-        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension = Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(Policy.LENIENT);
+        try (final MockedStatic<VaadinSessionActivationPolicyHolder> mockedExtension = Mockito.mockStatic(VaadinSessionActivationPolicyHolder.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(() -> VaadinSessionActivationPolicyHolder.get(Mockito.any(VaadinSession.class))).thenReturn(Policy.LENIENT);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
 
@@ -109,9 +110,9 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
         "true,  STRICT"
     })
     public void get_context_withLockAndPolicy(boolean hasLock, Policy policy) {
-        try (final MockedStatic<VaadinSessionScopedContext> mockedExtension =
-            Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedExtension.when(() -> VaadinSessionScopedContext.getActivationPolicy(Mockito.any(VaadinSession.class))).thenReturn(policy);
+        try (final MockedStatic<VaadinSessionActivationPolicyHolder> mockedExtension =
+            Mockito.mockStatic(VaadinSessionActivationPolicyHolder.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedExtension.when(() -> VaadinSessionActivationPolicyHolder.get(Mockito.any(VaadinSession.class))).thenReturn(policy);
             final SessionUnderTestContext context = new SessionUnderTestContext();
             context.activate();
             final VaadinSession session = context.getSession();

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -108,7 +108,7 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
         "false, LENIENT",
         "true,  STRICT"
     })
-    public void get_context_withLockAndLenientPolicy(boolean hasLock, Policy policy) {
+    public void get_context_withLockAndPolicy(boolean hasLock, Policy policy) {
         try (final MockedStatic<VaadinSessionScopedContext> mockedExtension =
             Mockito.mockStatic(VaadinSessionScopedContext.class, Mockito.CALLS_REAL_METHODS)) {
             mockedExtension.when(VaadinSessionScopedContext::getActivationPolicy).thenReturn(policy);

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/SessionContextTest.java
@@ -17,11 +17,19 @@
 package com.vaadin.cdi.context;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import jakarta.enterprise.context.ContextNotActiveException;
+
+import com.vaadin.cdi.VaadinExtension;
+import com.vaadin.cdi.annotation.VaadinSessionScopeActivationPolicy.Policy;
 import com.vaadin.cdi.annotation.VaadinSessionScoped;
 import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.flow.server.VaadinSession;
@@ -44,24 +52,52 @@ public class SessionContextTest extends AbstractContextTest<SessionContextTest.S
     }
 
     @Test
-    public void get_sessionExistsButNotLocked_contextNotActive() {
-        SessionUnderTestContext context = new SessionUnderTestContext();
-        context.activate();
+    public void get_context_withStrictPolicy_contextNotActive() {
+        try (final MockedStatic<VaadinExtension> mockedExtension = Mockito.mockStatic(VaadinExtension.class)) {
+            mockedExtension.when(VaadinExtension::getVaadinSessionScopeActivationPolicy).thenReturn(Policy.STRICT);
+            final SessionUnderTestContext context = new SessionUnderTestContext();
+            context.activate();
 
-        VaadinSession session = context.getSession();
-        when(session.hasLock()).thenReturn(false);
+            final VaadinSession session = context.getSession();
+            when(session.hasLock()).thenReturn(false);
 
-        VaadinSessionScopedContext sessionContext =
+            final VaadinSessionScopedContext sessionContext =
                 new VaadinSessionScopedContext(weld.select().select(
-                        jakarta.enterprise.inject.spi.BeanManager.class).get());
+                    jakarta.enterprise.inject.spi.BeanManager.class).get());
 
-        assertTrue(sessionContext.isActive());
+            assertFalse(sessionContext.isActive());
 
-        assertDoesNotThrow(() -> {
-            SessionScopedTestBean ref =
+            assertThrows(ContextNotActiveException.class, () -> {
+                SessionScopedTestBean ref =
                     BeanProvider.getContextualReference(SessionScopedTestBean.class);
-            ref.getState();
-        });
+                ref.getState();
+            });
+        }
+
+    }
+
+    @Test
+    public void get_context_withLenientPolicy() {
+        try (final MockedStatic<VaadinExtension> mockedExtension = Mockito.mockStatic(VaadinExtension.class)) {
+            mockedExtension.when(VaadinExtension::getVaadinSessionScopeActivationPolicy).thenReturn(Policy.LENIENT);
+            final SessionUnderTestContext context = new SessionUnderTestContext();
+            context.activate();
+
+            final VaadinSession session = context.getSession();
+            when(session.hasLock()).thenReturn(false);
+
+            final VaadinSessionScopedContext sessionContext =
+                new VaadinSessionScopedContext(weld.select().select(
+                    jakarta.enterprise.inject.spi.BeanManager.class).get());
+
+            assertTrue(sessionContext.isActive());
+
+            assertDoesNotThrow(() -> {
+                SessionScopedTestBean ref =
+                    BeanProvider.getContextualReference(SessionScopedTestBean.class);
+                ref.getState();
+            });
+        }
     }
 
     @VaadinSessionScoped


### PR DESCRIPTION
## Description

In a Multi-Threaded Application 1 View with 10 Threads for Example, with threads containing the UI and VaadinSession, the Threads could access the CDI-Scopes before the changes breaking changes in the isActive method.
These changes were reverted and instead the findContextualStorage Method was adapted to dynamically take the lock, if not already running on a UI-Thread. This simplifies the adaptation for the customers, due to them not having to change every single line of code where they accessing the VaadinSessionScoped beans.

Fixes #506

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.
