### PR TITLE
feat: add PageTitleGenerator support to CdiInstantiator

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/AbstractCdiInstantiator.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/AbstractCdiInstantiator.java
@@ -27,6 +27,7 @@ import com.vaadin.cdi.util.BeanProvider;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.router.PageTitleGenerator;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.auth.MenuAccessControl;
 
@@ -85,6 +86,13 @@ abstract public class AbstractCdiInstantiator implements Instantiator {
         final BeanLookup<MenuAccessControl> lookup = new BeanLookup<>(
                 getBeanManager(), MenuAccessControl.class, BeanLookup.SERVICE);
         return lookup.lookupOrElseGet(getDelegate()::getMenuAccessControl);
+    }
+
+    @Override
+    public PageTitleGenerator getPageTitleGenerator() {
+        final BeanLookup<PageTitleGenerator> lookup = new BeanLookup<>(
+                getBeanManager(), PageTitleGenerator.class, BeanLookup.SERVICE);
+        return lookup.lookupOrElseGet(getDelegate()::getPageTitleGenerator);
     }
 
     private static Logger getLogger() {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorDefaultsTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorDefaultsTest.java
@@ -31,6 +31,7 @@ import com.vaadin.cdi.annotation.VaadinServiceScoped;
 import com.vaadin.cdi.context.ServiceUnderTestContext;
 import com.vaadin.cdi.context.VaadinServiceScopedContext;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.router.PageTitleGenerator;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
 import com.vaadin.flow.server.auth.MenuAccessControl;
@@ -75,5 +76,14 @@ public class CdiInstantiatorDefaultsTest {
         Assertions.assertNotNull(menuAccessControl);
         Assertions.assertInstanceOf(DefaultMenuAccessControl.class,
                 menuAccessControl);
+    }
+
+    @Test
+    public void getPageTitleGenerator_beanNotProvided_fallsBackToDelegate() {
+        // No bean and no "pageTitle.generator" init parameter is configured,
+        // so the delegate's default (null) is returned.
+        PageTitleGenerator pageTitleGenerator = instantiator
+                .getPageTitleGenerator();
+        Assertions.assertNull(pageTitleGenerator);
     }
 }

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/CdiInstantiatorTest.java
@@ -42,6 +42,8 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.router.PageTitleContext;
+import com.vaadin.flow.router.PageTitleGenerator;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.auth.MenuAccessControl;
@@ -127,6 +129,15 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
         }
     }
 
+    @VaadinServiceEnabled
+    public static class TestPageTitleGenerator implements PageTitleGenerator {
+
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return null;
+        }
+    }
+
     @Singleton
     public static class ServiceInitObserver {
 
@@ -186,6 +197,15 @@ public class CdiInstantiatorTest extends AbstractWeldTest {
         Assertions.assertNotNull(menuAccessControl);
         Assertions.assertInstanceOf(TestMenuAccessControl.class,
                 menuAccessControl);
+    }
+
+    @Test
+    public void getPageTitleGenerator_beanEnabled_instanceReturned() {
+        PageTitleGenerator pageTitleGenerator = instantiator
+                .getPageTitleGenerator();
+        Assertions.assertNotNull(pageTitleGenerator);
+        Assertions.assertInstanceOf(TestPageTitleGenerator.class,
+                pageTitleGenerator);
     }
 
     @Test


### PR DESCRIPTION
Adds support for dependency injection of the `PageTitleGenerator` in the Vaadin CDI integration. It updates the `AbstractCdiInstantiator` to allow CDI beans to provide a custom `PageTitleGenerator`, with fallback to the delegate if none is provided.