### PR TITLE
Fix for EAR Deployment Issue

### DIFF
--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/DeltaSpikeConfigBootstrap.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/internal/DeltaSpikeConfigBootstrap.java
@@ -1,0 +1,87 @@
+/*
+ * Vaadin CDI Integration
+ *
+ * Copyright (C) 2012-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.cdi.internal;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.interceptor.Interceptor;
+
+import org.apache.deltaspike.core.api.config.ConfigResolver;
+
+/**
+ * Works around a DeltaSpike + EAR classloading problem on Jakarta EE servers
+ * (e.g. WildFly / JBoss EAP 8).
+ * <p>
+ * DeltaSpike's JMX {@code MBeanExtension} observes {@link BeforeBeanDiscovery}
+ * and, during that callback, resolves the DeltaSpike ProjectStage via
+ * {@link ConfigResolver#getConfigProvider()}. That method discovers its
+ * {@code ConfigProvider} implementation with {@code ServiceLoader} against the
+ * <em>thread context classloader</em>. When this add-on's WAR is nested inside
+ * an EAR, the TCCL active during CDI bootstrap is the EAR (parent) classloader,
+ * which cannot see {@code deltaspike-core-impl} in the WAR's {@code WEB-INF/lib}.
+ * The lookup then finds no provider and deployment fails with
+ * {@code java.lang.RuntimeException: Could not load ConfigProvider}.
+ * <p>
+ * This extension primes and caches the {@code ConfigProvider} early, while the
+ * TCCL is set to this class's classloader (the WAR module classloader, which can
+ * see {@code WEB-INF/lib}). {@link ConfigResolver} caches the provider in a
+ * static field, so DeltaSpike's later lookup returns the cached instance and
+ * never re-runs the failing {@code ServiceLoader} scan. DeltaSpike stays in the
+ * WAR, so runtime bean resolution is unaffected.
+ * <p>
+ * Ordering: Weld instantiates all extensions (their constructors) before firing
+ * {@link BeforeBeanDiscovery}, so the constructor below is guaranteed to run
+ * before DeltaSpike's {@code MBeanExtension.init}. The high-priority observer is
+ * a defensive fallback. The priming is a no-op cost (one cached lookup) for
+ * standalone WAR deployments, where the problem does not occur.
+ */
+public class DeltaSpikeConfigBootstrap implements Extension {
+
+    public DeltaSpikeConfigBootstrap() {
+        primeConfigProvider();
+    }
+
+    void primeBeforeBeanDiscovery(
+            @Observes @Priority(Interceptor.Priority.PLATFORM_BEFORE) BeforeBeanDiscovery beforeBeanDiscovery) {
+        primeConfigProvider();
+    }
+
+    private static void primeConfigProvider() {
+        final Thread thread = Thread.currentThread();
+        final ClassLoader previous = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(
+                    DeltaSpikeConfigBootstrap.class.getClassLoader());
+            // Triggers (and caches) the ServiceLoader-based ConfigProvider
+            // lookup now, with a TCCL that can see deltaspike-core-impl.
+            ConfigResolver.getConfigProvider();
+        } catch (RuntimeException e) {
+            // Priming is best-effort: if it fails, fall through and let the
+            // normal DeltaSpike code path run and surface the original error.
+            getLogger().log(Level.FINE,
+                    "Could not pre-initialize the DeltaSpike ConfigProvider; "
+                            + "falling back to the default bootstrap.",
+                    e);
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
+    }
+
+    private static Logger getLogger() {
+        return Logger.getLogger(DeltaSpikeConfigBootstrap.class.getCanonicalName());
+    }
+
+}

--- a/vaadin-cdi/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/vaadin-cdi/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,1 +1,2 @@
 com.vaadin.cdi.internal.VaadinExtension
+com.vaadin.cdi.internal.DeltaSpikeConfigBootstrap


### PR DESCRIPTION
## Description

DeltaSpike's JMX MBeanExtension observes BeforeBeanDiscovery and, during that callback, resolves the DeltaSpike ProjectStage via ConfigResolver.getConfigProvider(). That method discovers its ConfigProvider implementation using ServiceLoader against the thread context classloader (TCCL).

When this add-on's WAR is nested inside an EAR on a Jakarta EE server (e.g. WildFly / JBoss EAP 8), the TCCL active during CDI bootstrap is the EAR (parent) classloader, which cannot see deltaspike-core-impl in the WAR's WEB-INF/lib. The lookup finds no provider and deployment fails with:
`java.lang.RuntimeException: Could not load ConfigProvider`

  This PR adds a new CDI extension, DeltaSpikeConfigBootstrap, that primes and caches the DeltaSpike ConfigProvider early — while the TCCL is temporarily set to the WAR module classloader (which can see WEB-INF/lib). ConfigResolver caches the provider in a static field, so DeltaSpike's later lookup returns the cached instance and never re-runs the failing ServiceLoader scan. The priming is best-effort (failures are logged at FINE and fall back to the normal path), and is a negligible no-op cost for standalone WAR deployments where the problem doesn't occur.

Fixes #521

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
