### PR TITLE
fix: Compile to Java 17 bytecode for compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
 		<url>https://vaadin.com</url>
 	</organization>
 	<properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 	<build>
 		<plugins>

--- a/vaadin-cdi/pom.xml
+++ b/vaadin-cdi/pom.xml
@@ -19,9 +19,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <currentYear>2026</currentYear>
 
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <vaadin.version>8.31.1</vaadin.version>
         <deltaspike.version>2.0.0</deltaspike.version>


### PR DESCRIPTION
Previous use of Java 21 compile target was based on recommendations for Wildfly, but 17 is also a valid and (for now) supported runtime version, so we'll compile for that for maximum compatibility.