### PR TITLE
fix: bind route scope to window name only for `@PreserveOnRefresh`

### DIFF
--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutScopedPlainView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutScopedPlainView.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A plain sibling of {@link LayoutScopedPreservedView} under the same layout.
+ * The layout instance is reused when navigating between the two, so the beans
+ * it owns must not be recreated.
+ */
+@Route(value = "layout-scoped-plain", layout = MainLayout.class)
+@CdiComponent
+public class LayoutScopedPlainView extends Div {
+
+    public static final String LAYOUT_BEAN_LABEL = "plain-layout-bean";
+
+    @Inject
+    @RouteScopeOwner(MainLayout.class)
+    private Instance<MainLayoutBean> injection;
+
+    @PostConstruct
+    private void init() {
+        NativeLabel beanLabel = new NativeLabel(injection.get().getData());
+        beanLabel.setId(LAYOUT_BEAN_LABEL);
+        add(beanLabel);
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutScopedPreservedView.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/LayoutScopedPreservedView.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A preserved child of {@link MainLayout}, which is not preserved itself. Flow
+ * preserves the whole chain, so the beans owned by the layout are shared with
+ * the UI created by a page refresh.
+ */
+@PreserveOnRefresh
+@Route(value = "layout-scoped-preserved", layout = MainLayout.class)
+@CdiComponent
+public class LayoutScopedPreservedView extends Div {
+
+    public static final String LAYOUT_BEAN_LABEL = "preserved-layout-bean";
+
+    @Inject
+    @RouteScopeOwner(MainLayout.class)
+    private Instance<MainLayoutBean> injection;
+
+    private NativeLabel beanLabel;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        if (beanLabel != null) {
+            remove(beanLabel);
+        }
+        beanLabel = new NativeLabel(injection.get().getData());
+        beanLabel.setId(LAYOUT_BEAN_LABEL);
+        add(beanLabel);
+    }
+}

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayout.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayout.java
@@ -29,6 +29,8 @@ public class MainLayout extends Div implements RouterLayout {
     public static final String INVALID = "invalid";
     public static final String PARENT_NO_OWNER = "parent-no-owner";
     public static final String CHILD_NO_OWNER = "child-no-owner";
+    public static final String LAYOUT_PRESERVED = "layout-preserved";
+    public static final String LAYOUT_PLAIN = "layout-plain";
 
     private NativeLabel uiIdLabel;
 
@@ -36,7 +38,10 @@ public class MainLayout extends Div implements RouterLayout {
         add(new RouterLink(PRESERVE, PreserveOnRefreshView.class),
                 new RouterLink(INVALID, InvalidView.class),
                 new RouterLink(PARENT_NO_OWNER, ParentNoOwnerView.class),
-                new RouterLink(CHILD_NO_OWNER, ChildNoOwnerView.class));
+                new RouterLink(CHILD_NO_OWNER, ChildNoOwnerView.class),
+                new RouterLink(LAYOUT_PRESERVED,
+                        LayoutScopedPreservedView.class),
+                new RouterLink(LAYOUT_PLAIN, LayoutScopedPlainView.class));
         ;
     }
 

--- a/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayoutBean.java
+++ b/vaadin-cdi-itest/src/main/java/com/vaadin/cdi/itest/routecontext/MainLayoutBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.cdi.itest.routecontext;
+
+import jakarta.annotation.PostConstruct;
+
+import java.util.UUID;
+
+import com.vaadin.cdi.annotation.CdiComponent;
+import com.vaadin.cdi.annotation.RouteScopeOwner;
+import com.vaadin.cdi.annotation.RouteScoped;
+
+/**
+ * A bean owned by the layout shared by a preserved and a plain child view.
+ */
+@RouteScoped
+@RouteScopeOwner(MainLayout.class)
+@CdiComponent
+public class MainLayoutBean extends AbstractCountedBean {
+
+    @PostConstruct
+    private void init() {
+        setData(UUID.randomUUID().toString());
+    }
+
+}

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WindowType;
 
 import com.vaadin.cdi.itest.routecontext.ApartBean;
 import com.vaadin.cdi.itest.routecontext.AssignedBean;
@@ -295,6 +296,49 @@ public class RouteContextTest extends AbstractCdiTest {
         follow(MainLayout.PARENT_NO_OWNER);
 
         assertDestroyed(PreserveOnRefreshBean.class, 1);
+    }
+
+    @Test
+    public void noPreserveOnRefresh_routeTargetIsRecreatedOnRefresh()
+            throws IOException {
+        getDriver().get(getDriver().getCurrentUrl());
+
+        // UI ID has to be updated: all bean creations/removals will be done
+        // now within the new UI
+        uiId = getText(MainLayout.UIID);
+
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 0);
+        assertRootViewIsRendered();
+    }
+
+    @Test
+    public void noPreserveOnRefresh_otherUIWithSameWindowName_routeTargetIsNotShared()
+            throws IOException {
+        String url = getDriver().getCurrentUrl();
+        String windowName = (String) executeScript("return window.name;");
+
+        // Open a second tab and make it report the window name of the first
+        // one, as a duplicated tab or a restored browser session does. Both
+        // UIs are alive at the same time, so a route scope keyed by window
+        // name would be shared between them.
+        getDriver().switchTo().newWindow(WindowType.TAB);
+        getDriver().get(url);
+        executeScript("window.name = arguments[0];", windowName);
+        // same origin reload, so the window name is retained
+        getDriver().navigate().refresh();
+
+        uiId = getText(MainLayout.UIID);
+
+        assertConstructed(RootView.class, 1);
+        assertDestroyed(RootView.class, 0);
+        assertRootViewIsRendered();
+    }
+
+    private void assertRootViewIsRendered() {
+        Assert.assertNotNull(
+                "The root view is expected to be rendered in the current UI",
+                findElement(By.linkText(RootView.MASTER)));
     }
 
     @Test

--- a/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
+++ b/vaadin-cdi-itest/src/test/java/com/vaadin/cdi/itest/RouteContextTest.java
@@ -40,7 +40,10 @@ import com.vaadin.cdi.itest.routecontext.EventObserverLayout;
 import com.vaadin.cdi.itest.routecontext.EventView;
 import com.vaadin.cdi.itest.routecontext.LayoutEventView;
 import com.vaadin.cdi.itest.routecontext.LayoutEventView2;
+import com.vaadin.cdi.itest.routecontext.LayoutScopedPlainView;
+import com.vaadin.cdi.itest.routecontext.LayoutScopedPreservedView;
 import com.vaadin.cdi.itest.routecontext.MainLayout;
+import com.vaadin.cdi.itest.routecontext.MainLayoutBean;
 import com.vaadin.cdi.itest.routecontext.MasterView;
 import com.vaadin.cdi.itest.routecontext.PostponeView;
 import com.vaadin.cdi.itest.routecontext.PreserveOnRefreshBean;
@@ -333,6 +336,33 @@ public class RouteContextTest extends AbstractCdiTest {
         assertConstructed(RootView.class, 1);
         assertDestroyed(RootView.class, 0);
         assertRootViewIsRendered();
+    }
+
+    @Test
+    public void sharedLayout_navigateBetweenPreservedAndPlainChild_layoutBeanIsKept()
+            throws IOException {
+        follow(MainLayout.LAYOUT_PRESERVED);
+        String beanData = getText(LayoutScopedPreservedView.LAYOUT_BEAN_LABEL);
+
+        assertConstructed(MainLayoutBean.class, 1);
+        assertDestroyed(MainLayoutBean.class, 0);
+
+        // the layout instance is reused, so the beans it owns must not be
+        // recreated even if the navigation chain is not preserved anymore
+        follow(MainLayout.LAYOUT_PLAIN);
+
+        Assert.assertEquals(beanData,
+                getText(LayoutScopedPlainView.LAYOUT_BEAN_LABEL));
+        assertConstructed(MainLayoutBean.class, 1);
+        assertDestroyed(MainLayoutBean.class, 0);
+
+        // ... and the other way around
+        follow(MainLayout.LAYOUT_PRESERVED);
+
+        Assert.assertEquals(beanData,
+                getText(LayoutScopedPreservedView.LAYOUT_BEAN_LABEL));
+        assertConstructed(MainLayoutBean.class, 1);
+        assertDestroyed(MainLayoutBean.class, 0);
     }
 
     private void assertRootViewIsRendered() {

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -61,6 +61,13 @@ abstract class AbstractContextualStorageManager<K> implements Serializable {
         }
     }
 
+    protected void relocate(K from, K to) {
+        ContextualStorage storage = storageMap.remove(from);
+        if (storage != null) {
+            storageMap.put(to, storage);
+        }
+    }
+
     protected ContextualStorage newContextualStorage(K key) {
         // Not required by the spec, but in reality beans are
         // PassivationCapable.

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/AbstractContextualStorageManager.java
@@ -61,13 +61,6 @@ abstract class AbstractContextualStorageManager<K> implements Serializable {
         }
     }
 
-    protected void relocate(K from, K to) {
-        ContextualStorage storage = storageMap.remove(from);
-        if (storage != null) {
-            storageMap.put(to, storage);
-        }
-    }
-
     protected ContextualStorage newContextualStorage(K key) {
         // Not required by the spec, but in reality beans are
         // PassivationCapable.

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinSession;
 
@@ -54,6 +55,17 @@ public class RouteScopedContext extends AbstractContext {
     @VaadinSessionScoped
     public static class ContextualStorageManager
             extends AbstractContextualStorageManager<RouteStorageKey> {
+
+        /**
+         * Prefix of storage identifiers bound to a single UI instance.
+         */
+        private static final String UI_STORE_ID_PREFIX = "uid-";
+
+        /**
+         * Prefix of storage identifiers bound to a browser window, and thus
+         * shared by all the UIs of that window.
+         */
+        private static final String WINDOW_STORE_ID_PREFIX = "win-";
 
         public ContextualStorageManager() {
             // Session lock checked in VaadinSessionScopedContext while
@@ -92,10 +104,10 @@ public class RouteScopedContext extends AbstractContext {
 
         private void destroyDescopedBeans(UI ui,
                 Set<Class<?>> navigationChain) {
-            String uiStoreId = getUIStoreId(ui);
+            Set<String> uiStoreIds = getUIStoreIds(ui);
 
             Set<RouteStorageKey> missingKeys = getKeySet().stream()
-                    .filter(key -> key.getUIId().equals(uiStoreId))
+                    .filter(key -> uiStoreIds.contains(key.getUIId()))
                     .filter(key -> !navigationChain.contains(key.getOwner()))
                     .collect(Collectors.toSet());
 
@@ -103,6 +115,12 @@ public class RouteScopedContext extends AbstractContext {
         }
 
         private void handleUIDetach(UI ui, RouteStorageKey key) {
+            if (!key.isWindowScoped()) {
+                // The storage belongs to this UI only, so there is nothing to
+                // preserve for a potential UI created by a page refresh.
+                destroy(key);
+                return;
+            }
             UI uiAfterRefresh = findPreservingUI(ui);
             if (uiAfterRefresh == null) {
                 destroy(key);
@@ -131,36 +149,62 @@ public class RouteScopedContext extends AbstractContext {
         }
 
         private RouteStorageKey getKey(UI ui, Class<?> owner) {
-            ExtendedClientDetails details = ui.getInternals()
-                    .getExtendedClientDetails();
-            RouteStorageKey key = new RouteStorageKey(owner, getUIStoreId(ui));
-            if (details.getWindowName() == null) {
-                ui.getPage().retrieveExtendedClientDetails(
-                        det -> relocate(ui, key));
+            // Beans are shared with the UI created by a page refresh only if
+            // the navigation chain is preserved by Flow. In that case the
+            // storage is bound to the browser window, exactly like Flow binds
+            // the preserved component chain.
+            if (isPreserveOnRefreshChain(ui)) {
+                String windowName = getWindowName(ui);
+                if (windowName != null) {
+                    return new RouteStorageKey(owner,
+                            WINDOW_STORE_ID_PREFIX + windowName, true);
+                }
             }
-            return key;
-        }
-
-        private void relocate(UI ui, RouteStorageKey key) {
-            relocate(key,
-                    new RouteStorageKey(key.getOwner(), getUIStoreId(ui)));
+            return new RouteStorageKey(owner, getUIStoreId(ui), false);
         }
 
         private List<ContextualStorage> getActiveContextualStorages() {
-            return getKeySet().stream().filter(
-                    key -> key.getUIId().equals(getUIStoreId(UI.getCurrent())))
+            Set<String> uiStoreIds = getUIStoreIds(UI.getCurrent());
+            return getKeySet().stream()
+                    .filter(key -> uiStoreIds.contains(key.getUIId()))
                     .map(key -> getContextualStorage(key, false))
                     .collect(Collectors.toList());
         }
 
-        private String getUIStoreId(UI ui) {
-            ExtendedClientDetails details = ui.getInternals()
-                    .getExtendedClientDetails();
-            if (details.getWindowName() == null) {
-                return "uid-" + ui.getUIId();
-            } else {
-                return "win-" + getWindowName(ui);
+        /**
+         * Gets all the storage identifiers a UI can hold beans for: its own
+         * one, plus the one shared by all the UIs of the same browser window. A
+         * single UI may own both kinds of storage, for example after navigating
+         * from a regular view to a {@link PreserveOnRefresh} one.
+         */
+        private Set<String> getUIStoreIds(UI ui) {
+            Set<String> ids = new HashSet<>();
+            ids.add(getUIStoreId(ui));
+            String windowName = getWindowName(ui);
+            if (windowName != null) {
+                ids.add(WINDOW_STORE_ID_PREFIX + windowName);
             }
+            return ids;
+        }
+
+        private String getUIStoreId(UI ui) {
+            return UI_STORE_ID_PREFIX + ui.getUIId();
+        }
+
+        private static boolean isPreserveOnRefreshChain(UI ui) {
+            NavigationData data = ComponentUtil.getData(ui,
+                    NavigationData.class);
+            if (data == null) {
+                return false;
+            }
+            return isPreserveOnRefresh(data.getNavigationTarget())
+                    || data.getLayouts().stream().anyMatch(
+                            ContextualStorageManager::isPreserveOnRefresh);
+        }
+
+        private static boolean isPreserveOnRefresh(Class<?> clazz) {
+            return clazz != null
+                    && clazz.isAnnotationPresent(PreserveOnRefresh.class);
         }
 
     }
@@ -168,10 +212,14 @@ public class RouteScopedContext extends AbstractContext {
     private static class RouteStorageKey implements Serializable {
         private final Class<?> owner;
         private final String uiId;
+        // Derived from uiId, so it is not part of equals/hashCode
+        private final boolean windowScoped;
 
-        private RouteStorageKey(Class<?> owner, String uiId) {
+        private RouteStorageKey(Class<?> owner, String uiId,
+                boolean windowScoped) {
             this.owner = owner;
             this.uiId = uiId;
+            this.windowScoped = windowScoped;
         }
 
         @Override
@@ -202,6 +250,15 @@ public class RouteScopedContext extends AbstractContext {
 
         String getUIId() {
             return uiId;
+        }
+
+        /**
+         * Whether the storage is shared by all the UIs of the same browser
+         * window, as required to preserve beans of a {@link PreserveOnRefresh}
+         * navigation chain.
+         */
+        boolean isWindowScoped() {
+            return windowScoped;
         }
 
     }

--- a/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
+++ b/vaadin-cdi/src/main/java/com/vaadin/cdi/context/RouteScopedContext.java
@@ -115,6 +115,11 @@ public class RouteScopedContext extends AbstractContext {
         }
 
         private void handleUIDetach(UI ui, RouteStorageKey key) {
+            if (getContextualStorage(key, false) == null) {
+                // The storage has been relocated to another key because the
+                // scope of its owner changed, or it is already destroyed.
+                return;
+            }
             if (!key.isWindowScoped()) {
                 // The storage belongs to this UI only, so there is nothing to
                 // preserve for a potential UI created by a page refresh.
@@ -149,18 +154,51 @@ public class RouteScopedContext extends AbstractContext {
         }
 
         private RouteStorageKey getKey(UI ui, Class<?> owner) {
+            RouteStorageKey uiKey = new RouteStorageKey(owner, getUIStoreId(ui),
+                    false);
+            String windowName = getWindowName(ui);
+            if (windowName == null) {
+                return uiKey;
+            }
+            RouteStorageKey windowKey = new RouteStorageKey(owner,
+                    WINDOW_STORE_ID_PREFIX + windowName, true);
             // Beans are shared with the UI created by a page refresh only if
             // the navigation chain is preserved by Flow. In that case the
             // storage is bound to the browser window, exactly like Flow binds
             // the preserved component chain.
             if (isPreserveOnRefreshChain(ui)) {
-                String windowName = getWindowName(ui);
-                if (windowName != null) {
-                    return new RouteStorageKey(owner,
-                            WINDOW_STORE_ID_PREFIX + windowName, true);
-                }
+                return rescope(uiKey, windowKey, ui);
             }
-            return new RouteStorageKey(owner, getUIStoreId(ui), false);
+            // The owner may stay in the navigation chain while the chain stops
+            // being preserved, for example navigating from a preserved view to
+            // a plain sibling of the same layout. Its beans are then bound back
+            // to this UI, unless another UI of the same browser window is still
+            // alive and may be holding the preserved chain.
+            if (getContextualStorage(windowKey, false) != null
+                    && findPreservingUI(ui) == null) {
+                return rescope(windowKey, uiKey, ui);
+            }
+            return uiKey;
+        }
+
+        /**
+         * Moves the storage of an owner whose scope changed, so that its beans
+         * are not recreated while the owner stays in the navigation chain.
+         *
+         * @return the key the storage of the owner is bound to, always
+         *         {@code to}
+         */
+        private RouteStorageKey rescope(RouteStorageKey from,
+                RouteStorageKey to, UI ui) {
+            if (getContextualStorage(to, false) == null
+                    && getContextualStorage(from, false) != null) {
+                relocate(from, to);
+                // The listener registered for the previous key does not find
+                // any storage anymore, so the new key needs its own.
+                ui.addDetachListener(
+                        event -> handleUIDetach(event.getUI(), to));
+            }
+            return to;
         }
 
         private List<ContextualStorage> getActiveContextualStorages() {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
@@ -116,6 +116,27 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
         }
     }
 
+    /**
+     * A layout without {@link PreserveOnRefresh}, shared by a preserved and a
+     * plain child. Flow reuses the same layout instance when navigating between
+     * the two, and preserves it on refresh together with the preserved child.
+     */
+    public static class SharedLayout extends HasElementTestBean
+            implements RouterLayout {
+    }
+
+    @RouteScoped
+    @RouteScopeOwner(SharedLayout.class)
+    public static class MemberOfSharedLayout extends HasElementTestBean {
+
+        boolean isDestroyed;
+
+        @PreDestroy
+        private void onDestroy() {
+            isDestroyed = true;
+        }
+    }
+
     @Route("")
     public static class InitialRoute extends HasElementTestBean {
 
@@ -150,6 +171,10 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
 
     @Inject
     private Provider<NoOwnerBean> noOwnerBean;
+
+    @Inject
+    @RouteScopeOwner(SharedLayout.class)
+    private Provider<MemberOfSharedLayout> memberOfSharedLayout;
 
     @Inject
     private Event<BeforeEnterEvent> beforeNavigationTrigger;
@@ -394,11 +419,126 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
     }
 
     @Test
+    public void sharedLayout_navigateFromPreservedChildToPlainChild_layoutBeanIsKept() {
+        doSetUp("foo", null);
+
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+        MemberOfSharedLayout bean1 = memberOfSharedLayout.get();
+        bean1.setState(STATE);
+
+        // the layout instance is reused by Flow, so its beans must survive
+        navigateTo(Group1.class, SharedLayout.class);
+
+        MemberOfSharedLayout bean2 = memberOfSharedLayout.get();
+        Assertions.assertFalse(bean1.isDestroyed,
+                "The layout owned bean must not be destroyed while the layout "
+                        + "stays in the navigation chain");
+        Assertions.assertSame(bean1, bean2,
+                "The layout owned bean must stay the same instance while the "
+                        + "layout is reused across navigations");
+        Assertions.assertEquals(STATE, bean2.getState());
+    }
+
+    @Test
+    public void sharedLayout_navigateFromPlainChildToPreservedChild_layoutBeanIsKept() {
+        doSetUp("foo", null);
+
+        navigateTo(Group1.class, SharedLayout.class);
+        MemberOfSharedLayout bean1 = memberOfSharedLayout.get();
+        bean1.setState(STATE);
+
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+
+        MemberOfSharedLayout bean2 = memberOfSharedLayout.get();
+        Assertions.assertFalse(bean1.isDestroyed,
+                "The layout owned bean must not be destroyed while the layout "
+                        + "stays in the navigation chain");
+        Assertions.assertSame(bean1, bean2,
+                "The layout owned bean must stay the same instance when the "
+                        + "navigation chain becomes preserved");
+        Assertions.assertEquals(STATE, bean2.getState());
+    }
+
+    @Test
+    public void sharedLayout_navigateBackAndForth_layoutBeanIsKept() {
+        doSetUp("foo", null);
+
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+        MemberOfSharedLayout bean = memberOfSharedLayout.get();
+        bean.setState(STATE);
+
+        navigateTo(Group1.class, SharedLayout.class);
+        MemberOfSharedLayout beanOnPlainChild = memberOfSharedLayout.get();
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+
+        Assertions.assertFalse(bean.isDestroyed);
+        Assertions.assertSame(bean, beanOnPlainChild,
+                "The layout owned bean must stay the same instance when the "
+                        + "navigation chain is not preserved anymore");
+        Assertions.assertSame(bean, memberOfSharedLayout.get(),
+                "The layout owned bean must stay the same instance when the "
+                        + "navigation chain is preserved again");
+        Assertions.assertEquals(STATE, memberOfSharedLayout.get().getState());
+    }
+
+    @Test
+    public void sharedLayout_beanReboundToUI_isDestroyedOnUIDetach() {
+        UI ui = doSetUp("foo", null);
+
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+        MemberOfSharedLayout bean = memberOfSharedLayout.get();
+
+        // the chain is not preserved anymore, so the bean is bound to this UI
+        navigateTo(Group1.class, SharedLayout.class);
+        Assertions.assertSame(bean, memberOfSharedLayout.get());
+
+        // set another UI instance with the same window name into the context,
+        // simulating e.g. a page refresh
+        doSetUp("foo", ui.getSession());
+        ComponentUtil.onComponentDetach(ui);
+
+        Assertions.assertTrue(bean.isDestroyed,
+                "The layout owned bean is not preserved anymore, so it must be "
+                        + "destroyed together with its UI");
+    }
+
+    @Test
+    public void sharedLayout_anotherUIHoldsPreservedChain_beanIsNotStolen() {
+        UI ui = doSetUp("foo", null);
+
+        navigateTo(PreservedGroup.class, SharedLayout.class);
+        MemberOfSharedLayout bean1 = memberOfSharedLayout.get();
+        bean1.setState(STATE);
+
+        // set another UI instance with the same window name into the context,
+        // both UIs being alive at the same time
+        doSetUp("foo", ui.getSession());
+        navigateTo(Group1.class, SharedLayout.class);
+
+        MemberOfSharedLayout bean2 = memberOfSharedLayout.get();
+        Assertions.assertNotSame(bean1, bean2,
+                "The beans of a not preserved navigation chain must not be "
+                        + "taken from a UI that may still hold the preserved "
+                        + "chain");
+        Assertions.assertNotEquals(STATE, bean2.getState());
+        Assertions.assertFalse(bean1.isDestroyed);
+    }
+
+    @Test
     public void onBeforeEnter_conditionalBean_doesNotThrow() {
         Mockito.when(event.getNavigationTarget())
                 .thenReturn((Class) InitialRoute.class);
         beforeNavigationTrigger.fire(event);
         customEventEventTrigger.fire(new CustomEvent());
+    }
+
+    private void navigateTo(Class navigationTarget,
+            Class<? extends RouterLayout> layout) {
+        Mockito.when(event.getNavigationTarget()).thenReturn(navigationTarget);
+        Mockito.when(event.getLayouts()).thenReturn(
+                Collections.<Class<? extends RouterLayout>> singletonList(
+                        layout));
+        beforeNavigationTrigger.fire(event);
     }
 
     private UI doSetUp(String windowName, VaadinSession session) {

--- a/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
+++ b/vaadin-cdi/src/test/java/com/vaadin/cdi/context/RouteContextualStorageManagerTest.java
@@ -45,7 +45,9 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.LocationChangeEvent;
+import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinSession;
 
 public class RouteContextualStorageManagerTest extends AbstractWeldTest {
@@ -92,6 +94,28 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
     public static class Group2 extends HasElementTestBean {
     }
 
+    @Route("preserved")
+    @PreserveOnRefresh
+    public static class PreservedGroup extends HasElementTestBean {
+    }
+
+    @PreserveOnRefresh
+    public static class PreservedLayout extends HasElementTestBean
+            implements RouterLayout {
+    }
+
+    @RouteScoped
+    @RouteScopeOwner(PreservedGroup.class)
+    public static class MemberOfPreservedGroup extends HasElementTestBean {
+
+        boolean isDestroyed;
+
+        @PreDestroy
+        private void onDestroy() {
+            isDestroyed = true;
+        }
+    }
+
     @Route("")
     public static class InitialRoute extends HasElementTestBean {
 
@@ -119,6 +143,10 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
     @Inject
     @RouteScopeOwner(Group1.class)
     private Provider<MemberOfGroup1> memberOfGroup1;
+
+    @Inject
+    @RouteScopeOwner(PreservedGroup.class)
+    private Provider<MemberOfPreservedGroup> memberOfPreservedGroup;
 
     @Inject
     private Provider<NoOwnerBean> noOwnerBean;
@@ -232,7 +260,64 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
     public void preserveOnRefresh_anotherUIHasSameWindowName_beanIsPreserved() {
         UI ui = doSetUp("foo", null);
         Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) PreservedGroup.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfPreservedGroup bean1 = memberOfPreservedGroup.get();
+        bean1.setState(STATE);
+
+        // set another UI instance with the same window name into the context
+        doSetUp("foo", ui.getSession());
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) PreservedGroup.class);
+        beforeNavigationTrigger.fire(event);
+
+        ComponentUtil.onComponentDetach(ui);
+
+        Assertions.assertFalse(bean1.isDestroyed);
+        Assertions.assertSame(bean1, memberOfPreservedGroup.get());
+        Assertions.assertEquals(STATE, memberOfPreservedGroup.get().getState());
+    }
+
+    @Test
+    public void noPreserveOnRefresh_anotherUIHasSameWindowName_beanIsNotShared() {
+        UI ui = doSetUp("foo", null);
+        Mockito.when(event.getNavigationTarget())
                 .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean1 = memberOfGroup1.get();
+        bean1.setState(STATE);
+
+        // set another UI instance with the same window name into the context,
+        // simulating e.g. a page refresh or a duplicated browser tab
+        doSetUp("foo", ui.getSession());
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean2 = memberOfGroup1.get();
+        Assertions.assertNotSame(bean1, bean2,
+                "Beans of a not preserved navigation chain must not be shared "
+                        + "between UIs of the same browser window");
+        Assertions.assertNotEquals(STATE, bean2.getState());
+
+        // the bean of the first UI is still bound to that UI only, and is
+        // destroyed together with it
+        Assertions.assertFalse(bean1.isDestroyed);
+        ComponentUtil.onComponentDetach(ui);
+        Assertions.assertTrue(bean1.isDestroyed);
+        Assertions.assertFalse(bean2.isDestroyed);
+    }
+
+    @Test
+    public void preserveOnRefreshLayout_anotherUIHasSameWindowName_beanIsPreserved() {
+        UI ui = doSetUp("foo", null);
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        Mockito.when(event.getLayouts()).thenReturn(
+                Collections.<Class<? extends RouterLayout>> singletonList(
+                        PreservedLayout.class));
         beforeNavigationTrigger.fire(event);
 
         MemberOfGroup1 bean1 = memberOfGroup1.get();
@@ -242,11 +327,15 @@ public class RouteContextualStorageManagerTest extends AbstractWeldTest {
         doSetUp("foo", ui.getSession());
         Mockito.when(event.getNavigationTarget())
                 .thenReturn((Class) Group1.class);
+        Mockito.when(event.getLayouts()).thenReturn(
+                Collections.<Class<? extends RouterLayout>> singletonList(
+                        PreservedLayout.class));
         beforeNavigationTrigger.fire(event);
 
         ComponentUtil.onComponentDetach(ui);
 
         Assertions.assertFalse(bean1.isDestroyed);
+        Assertions.assertSame(bean1, memberOfGroup1.get());
         Assertions.assertEquals(STATE, memberOfGroup1.get().getState());
     }
 


### PR DESCRIPTION
Route scope storage was keyed by window name whenever the extended client details reported one. That check used to be an implicit `@PreserveOnRefresh` detector: up to Vaadin 24, Flow requested the window name only for preserved navigation chains.

Since vaadin/flow#22719 the client details are collected during UI initialization and every tab gets a window name, so the check is always true. All `@RouteScoped` beans became shared between the UIs of the same browser window. When two such UIs are alive at the same time (duplicated tab, restored session, or reloads faster than the unload beacons that close the previous UI), the second UI is given a route target that still belongs to the first UI's state tree, and navigation fails with "Can't move a node from one state tree to another".

The storage is now bound to the window only when the navigation target or one of its layouts is annotated with `@PreserveOnRefresh`, mirroring Flow's isPreserveOnRefreshTarget rule. Otherwise it is bound to a single UI and destroyed on its detach.

Fixes #526
